### PR TITLE
Separate PreMOSA from DynaMOSA

### DIFF
--- a/client/src/main/java/org/evosuite/Properties.java
+++ b/client/src/main/java/org/evosuite/Properties.java
@@ -1314,6 +1314,9 @@ public class Properties {
 			" trigger the inclusion of non buggy goals")
 	public static int ZERO_COVERAGE_TRIGGER = 25;
 
+	@Parameter(key = "balance_test_cov", description = "Enable balanced test coverage of targets")
+	public static boolean BALANCE_TEST_COV = false;
+
 	// ---------------------------------------------------------------
 	// Contracts / Asserts:
 	@Parameter(key = "check_contracts", description = "Check contracts during test execution")

--- a/client/src/main/java/org/evosuite/Properties.java
+++ b/client/src/main/java/org/evosuite/Properties.java
@@ -315,7 +315,7 @@ public class Properties {
 		// mu-lambda
 		ONE_PLUS_LAMBDA_LAMBDA_GA, ONE_PLUS_ONE_EA, MU_PLUS_LAMBDA_EA, MU_LAMBDA_EA,
 		// many-objective algorithms
-		MOSA, DYNAMOSA, LIPS, MIO,
+		MOSA, DYNAMOSA, LIPS, MIO, PREMOSA,
 		// multiple-objective optimisation algorithms
 		NSGAII, SPEA2
 	}

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/DynaMOSA.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/DynaMOSA.java
@@ -134,6 +134,43 @@ public class DynaMOSA<T extends Chromosome> extends AbstractMOSA<T> {
 	}
 
 	/**
+	 * Switch on/off current goals to balance test coverage among goals based on number of tests per an independent
+	 * path of each goal
+	 */
+	protected void adjustCurrentGoals() {
+		for (int actualBranchId : this.goalsManager.getBranchCoverageTrueMap().keySet()) {
+			FitnessFunction ffTrue = this.goalsManager.getBranchCoverageTrueMap().get(actualBranchId);
+			FitnessFunction ffFalse = this.goalsManager.getBranchCoverageFalseMap().get(actualBranchId);
+
+			int numTestsTrueBranch = this.goalsManager.getNumTests(ffTrue.toString());
+			int numTestsFalseBranch = this.goalsManager.getNumTests(ffFalse.toString());
+
+			logger.debug("Branch: {}, Number of Tests: {}, Num of Paths: {}", ffTrue.toString(), numTestsTrueBranch,
+					this.goalsManager.getNumPathsFor(ffTrue));
+			logger.debug("Branch: {}, Number of Tests: {}, Num of Paths: {}", ffFalse.toString(), numTestsFalseBranch,
+					this.goalsManager.getNumPathsFor(ffFalse));
+
+			if (numTestsTrueBranch == 0 && numTestsFalseBranch == 0) {
+				continue;
+			}
+
+			int numPathsTrueBranch = this.goalsManager.getNumPathsFor(ffTrue);
+			int numPathsFalseBranch = this.goalsManager.getNumPathsFor(ffFalse);
+
+			double testsPerPathTrueB = (double) numTestsTrueBranch / numPathsTrueBranch;
+			double testsPerPathFalseB = (double) numTestsFalseBranch / numPathsFalseBranch;
+
+			if (Double.compare(testsPerPathTrueB, testsPerPathFalseB) > 0) {
+				this.goalsManager.getCurrentGoals().remove(ffTrue);
+				this.goalsManager.getCurrentGoals().add(ffFalse);
+			} else if (Double.compare(testsPerPathTrueB, testsPerPathFalseB) < 0) {
+				this.goalsManager.getCurrentGoals().remove(ffFalse);
+				this.goalsManager.getCurrentGoals().add(ffTrue);
+			}
+		}
+	}
+
+	/**
 	 * {@inheritDoc}
 	 */
 	@Override

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/DynaMOSA.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/DynaMOSA.java
@@ -133,54 +133,6 @@ public class DynaMOSA<T extends Chromosome> extends AbstractMOSA<T> {
 
 		this.currentIteration++;
 
-		if (!triggerFired) {
-			if (goalsManager.getUncoveredGoals().size() == this.currentUncoveredGoals) {
-				this.currentIterationsWoImprovements++;
-			} else {
-				this.currentUncoveredGoals = goalsManager.getUncoveredGoals().size();
-				this.currentIterationsWoImprovements = 0;
-			}
-
-			if (this.currentIterationsWoImprovements >= Properties.ITERATIONS_WO_IMPROVEMENT) {
-				// trigger point to include non-buggy goals
-				this.triggerFired = true;
-				goalsManager.updateCurrentGoals();
-				goalsManager.updateUncoveredGoals();
-				goalsManager.updateMethods();
-				goalsManager.updateBranchCoverageMaps();
-
-				LoggingUtils.getEvoLogger().info(
-						"Trigger to include non-buggy goals fired at {} seconds after {} generations",
-						(int) (this.getCurrentTime() / 1000), this.currentIteration);
-				LoggingUtils.getEvoLogger().info(
-						"Trigger cause: Buggy goals coverage is not improved for {} generations, current uncovered goals {}",
-						this.currentIterationsWoImprovements, this.currentUncoveredGoals);
-			}
-		}
-
-		if (zeroGoalsCovered) {
-			if (goalsManager.getCoveredGoals().size() > 0) {
-				zeroGoalsCovered = false;
-			}
-		}
-
-		if (zeroGoalsCovered && !triggerFired) {
-			if (this.currentIteration >= Properties.ZERO_COVERAGE_TRIGGER) {
-				this.triggerFired = true;
-				goalsManager.updateCurrentGoals();
-				goalsManager.updateUncoveredGoals();
-				goalsManager.updateMethods();
-				goalsManager.updateBranchCoverageMaps();
-
-				LoggingUtils.getEvoLogger().info(
-						"Trigger to include non-buggy goals fired at {} seconds after {} generations",
-						(int) (this.getCurrentTime() / 1000), this.currentIteration);
-				LoggingUtils.getEvoLogger().info(
-						"Trigger cause: Buggy goals coverage is zero for {} generations, current uncovered goals {}",
-						this.currentIteration, this.currentUncoveredGoals);
-			}
-		}
-
 		logger.debug("Covered goals = {}", goalsManager.getCoveredGoals().size());
 		logger.debug("Current goals = {}", goalsManager.getCurrentGoals().size());
 		logger.debug("Uncovered goals = {}", goalsManager.getUncoveredGoals().size());

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/DynaMOSA.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/DynaMOSA.java
@@ -58,11 +58,6 @@ public class DynaMOSA<T extends Chromosome> extends AbstractMOSA<T> {
 
 	protected CrowdingDistance<T> distance = new CrowdingDistance<T>();
 
-	private int currentIterationsWoImprovements = 0;
-	private int currentUncoveredGoals = 0;
-	private boolean triggerFired = false;
-	private boolean zeroGoalsCovered = true;
-
 	/**
 	 * Constructor based on the abstract class {@link AbstractMOSA}.
 	 * 
@@ -146,21 +141,6 @@ public class DynaMOSA<T extends Chromosome> extends AbstractMOSA<T> {
 		logger.debug("executing generateSolution function");
 
 		this.goalsManager = new MultiCriteriatManager<T>(this.fitnessFunctions);
-
-		if (this.goalsManager.getCurrentGoals().size() == 0) {
-			// trigger point to include non-buggy goals
-			this.triggerFired = true;
-			goalsManager.updateCurrentGoals();
-			goalsManager.updateUncoveredGoals();
-			goalsManager.updateMethods();
-			goalsManager.updateBranchCoverageMaps();
-
-			LoggingUtils.getEvoLogger().info(
-					"Trigger to include non-buggy goals fired at {} seconds after {} generations",
-					(int) (this.getCurrentTime() / 1000), this.currentIteration);
-			LoggingUtils.getEvoLogger().info("Trigger cause: No buggy goals");
-		}
-
 		LoggingUtils.getEvoLogger().info("* Initial Number of Goals in DynMOSA = " +
 				this.goalsManager.getCurrentGoals().size() +" / "+ this.getUncoveredGoals().size());
 
@@ -179,14 +159,6 @@ public class DynaMOSA<T extends Chromosome> extends AbstractMOSA<T> {
 
 		for (int i = 0; i < this.rankingFunction.getNumberOfSubfronts(); i++){
 			this.distance.fastEpsilonDominanceAssignment(this.rankingFunction.getSubfront(i), this.goalsManager.getCurrentGoals());
-		}
-
-		this.currentUncoveredGoals = goalsManager.getUncoveredGoals().size();
-
-		if (zeroGoalsCovered) {
-			if (goalsManager.getCoveredGoals().size() > 0) {
-				zeroGoalsCovered = false;
-			}
 		}
 
 		// next generations

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/DynaMOSA.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/DynaMOSA.java
@@ -58,6 +58,9 @@ public class DynaMOSA<T extends Chromosome> extends AbstractMOSA<T> {
 
 	protected CrowdingDistance<T> distance = new CrowdingDistance<T>();
 
+	/** Total time taken to adjust the goals (switch on/off goals) in nano seconds */
+	protected long adjustGoalsOH = 0;
+
 	/**
 	 * Constructor based on the abstract class {@link AbstractMOSA}.
 	 * 
@@ -79,6 +82,15 @@ public class DynaMOSA<T extends Chromosome> extends AbstractMOSA<T> {
 
 		// Ranking the union
 		logger.debug("Union Size = {}", union.size());
+
+		if (Properties.BALANCE_TEST_COV) {
+			// Switch off targets to balance test coverage
+			long adjustGoalsStartTime = System.nanoTime();
+			adjustCurrentGoals();
+			long adjustGoalEndTime = System.nanoTime();
+
+			this.adjustGoalsOH += adjustGoalEndTime - adjustGoalsStartTime;
+		}
 
 		// Ranking the union using the best rank algorithm (modified version of the non dominated sorting algorithm
 		this.rankingFunction.computeRankingAssignment(union, this.goalsManager.getCurrentGoals());
@@ -202,6 +214,10 @@ public class DynaMOSA<T extends Chromosome> extends AbstractMOSA<T> {
 		while (!isFinished() /*&& this.goalsManager.getUncoveredGoals().size() > 0*/) {
 			this.evolve();
 			this.notifyIteration();
+		}
+
+		if (Properties.BALANCE_TEST_COV) {
+			LoggingUtils.getEvoLogger().info("* Adjust Goals Overhead: {} ms", (double) (this.adjustGoalsOH) / 1000000);
 		}
 
 		this.notifySearchFinished();

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/PreMOSA.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/PreMOSA.java
@@ -91,7 +91,7 @@ public class PreMOSA<T extends Chromosome> extends DynaMOSA<T> {
 
         // Switch off targets to balance test coverage
         long adjustGoalsStartTime = System.nanoTime();
-        adjustCurrentGoals(false);
+        adjustCurrentGoals();
         long adjustGoalEndTime = System.nanoTime();
 
         this.adjustGoalsOH += adjustGoalEndTime - adjustGoalsStartTime;
@@ -197,7 +197,12 @@ public class PreMOSA<T extends Chromosome> extends DynaMOSA<T> {
         logger.debug("Uncovered goals = {}", goalsManager.getUncoveredGoals().size());
     }
 
-    private void adjustCurrentGoals(boolean logInfo) {
+    /**
+     * Switch on/off current goals to balance test coverage among goals based on number of tests per an independent
+     * path of each goal
+     *
+     */
+    private void adjustCurrentGoals() {
         for (int actualBranchId : this.goalsManager.getBranchCoverageTrueMap().keySet()) {
             FitnessFunction ffTrue = this.goalsManager.getBranchCoverageTrueMap().get(actualBranchId);
             FitnessFunction ffFalse = this.goalsManager.getBranchCoverageFalseMap().get(actualBranchId);
@@ -205,12 +210,10 @@ public class PreMOSA<T extends Chromosome> extends DynaMOSA<T> {
             int numTestsTrueBranch = this.goalsManager.getNumTests(ffTrue.toString());
             int numTestsFalseBranch = this.goalsManager.getNumTests(ffFalse.toString());
 
-            if (logInfo) {
-                LoggingUtils.getEvoLogger().info("Branch: {}, Number of Tests: {}, Num of Paths: {}", ffTrue.toString(),
-                        numTestsTrueBranch, this.goalsManager.getNumPathsFor(ffTrue));
-                LoggingUtils.getEvoLogger().info("Branch: {}, Number of Tests: {}, Num of Paths: {}", ffFalse.toString(),
-                        numTestsFalseBranch, this.goalsManager.getNumPathsFor(ffFalse));
-            }
+            logger.debug("Branch: {}, Number of Tests: {}, Num of Paths: {}", ffTrue.toString(), numTestsTrueBranch,
+                    this.goalsManager.getNumPathsFor(ffTrue));
+            logger.debug("Branch: {}, Number of Tests: {}, Num of Paths: {}", ffFalse.toString(), numTestsFalseBranch,
+                    this.goalsManager.getNumPathsFor(ffFalse));
 
             if (numTestsTrueBranch == 0 && numTestsFalseBranch == 0) {
                 continue;
@@ -228,24 +231,7 @@ public class PreMOSA<T extends Chromosome> extends DynaMOSA<T> {
             } else if (Double.compare(testsPerPathTrueB, testsPerPathFalseB) < 0) {
                 this.goalsManager.getCurrentGoals().remove(ffFalse);
                 this.goalsManager.getCurrentGoals().add(ffTrue);
-            } else {
-                continue;
             }
-
-			/*numTestsTrueBranch = numTestsTrueBranch == 0 ? 1 : numTestsTrueBranch;
-			numTestsFalseBranch = numTestsFalseBranch == 0 ? 1 : numTestsFalseBranch;
-
-			double scaleUpFactor = (double) numTestsTrueBranch / numTestsFalseBranch;
-			if (Double.compare(scaleUpFactor, 1.0) > 0) {	// True Branch has more tests
-				((BranchCoverageTestFitness) ffFalse).setNumTestCasesInZeroFront((int) Math.ceil(scaleUpFactor * 1));
-				// 1 - Default Num Test Cases in Zero Front
-				((BranchCoverageTestFitness) ffTrue).setNumTestCasesInZeroFront(0);
-			} else {	// False Branch has more tests
-				((BranchCoverageTestFitness) ffTrue).setNumTestCasesInZeroFront((int) Math.ceil(1 / scaleUpFactor));
-				// 1 - Default Num Test Cases in Zero Front
-				((BranchCoverageTestFitness) ffFalse).setNumTestCasesInZeroFront(0);
-			}*/
-
         }
     }
 
@@ -306,7 +292,6 @@ public class PreMOSA<T extends Chromosome> extends DynaMOSA<T> {
             this.notifyIteration();
         }
 
-        adjustCurrentGoals(true);
         LoggingUtils.getEvoLogger().info("Adjust Goals Overhead: {} ms",
                 (double) (this.adjustGoalsOH) / 1000000);
 

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/PreMOSA.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/PreMOSA.java
@@ -31,6 +31,7 @@ import org.evosuite.ga.ChromosomeFactory;
 import org.evosuite.ga.FitnessFunction;
 import org.evosuite.ga.comparators.OnlyCrowdingComparator;
 import org.evosuite.ga.metaheuristics.mosa.structural.MultiCriteriatManager;
+import org.evosuite.ga.metaheuristics.mosa.structural.PredictiveCriteriaManager;
 import org.evosuite.ga.metaheuristics.mosa.structural.StructuralGoalManager;
 import org.evosuite.ga.operators.ranking.CrowdingDistance;
 import org.evosuite.testcase.TestChromosome;
@@ -51,6 +52,9 @@ public class PreMOSA<T extends Chromosome> extends DynaMOSA<T> {
     private static final long serialVersionUID = 146182080947267628L;
 
     private static final Logger logger = LoggerFactory.getLogger(PreMOSA.class);
+
+    /** Manager to determine the test goals to consider at each generation */
+    protected PredictiveCriteriaManager<T> goalsManager = null;
 
     /** Total time taken to adjust the goals (switch on/off goals) in nano seconds */
     private long adjustGoalsOH = 0;
@@ -254,7 +258,7 @@ public class PreMOSA<T extends Chromosome> extends DynaMOSA<T> {
     public void generateSolution() {
         logger.debug("executing generateSolution function");
 
-        this.goalsManager = new MultiCriteriatManager<T>(this.fitnessFunctions);
+        this.goalsManager = new PredictiveCriteriaManager<T>(this.fitnessFunctions);
 
         if (this.goalsManager.getCurrentGoals().size() == 0) {
             // trigger point to include non-buggy goals

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/PreMOSA.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/PreMOSA.java
@@ -53,9 +53,6 @@ public class PreMOSA<T extends Chromosome> extends DynaMOSA<T> {
 
     private static final Logger logger = LoggerFactory.getLogger(PreMOSA.class);
 
-    /** Total time taken to adjust the goals (switch on/off goals) in nano seconds */
-    private long adjustGoalsOH = 0;
-
     /** Number of current consecutive iterations without buggy goals coverage improvement */
     private int currentIterationsWoImprovements = 0;
 
@@ -90,12 +87,14 @@ public class PreMOSA<T extends Chromosome> extends DynaMOSA<T> {
         // Ranking the union
         logger.debug("Union Size = {}", union.size());
 
-        // Switch off targets to balance test coverage
-        long adjustGoalsStartTime = System.nanoTime();
-        adjustCurrentGoals();
-        long adjustGoalEndTime = System.nanoTime();
+        if (Properties.BALANCE_TEST_COV) {
+            // Switch off targets to balance test coverage
+            long adjustGoalsStartTime = System.nanoTime();
+            adjustCurrentGoals();
+            long adjustGoalEndTime = System.nanoTime();
 
-        this.adjustGoalsOH += adjustGoalEndTime - adjustGoalsStartTime;
+            this.adjustGoalsOH += adjustGoalEndTime - adjustGoalsStartTime;
+        }
 
         // Ranking the union using the best rank algorithm (modified version of the non dominated sorting algorithm
         this.rankingFunction.computeRankingAssignment(union, this.goalsManager.getCurrentGoals());
@@ -266,7 +265,9 @@ public class PreMOSA<T extends Chromosome> extends DynaMOSA<T> {
             this.notifyIteration();
         }
 
-        LoggingUtils.getEvoLogger().info("* Adjust Goals Overhead: {} ms", (double) (this.adjustGoalsOH) / 1000000);
+        if (Properties.BALANCE_TEST_COV) {
+            LoggingUtils.getEvoLogger().info("* Adjust Goals Overhead: {} ms", (double) (this.adjustGoalsOH) / 1000000);
+        }
 
         this.notifySearchFinished();
     }

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/PreMOSA.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/PreMOSA.java
@@ -259,15 +259,12 @@ public class PreMOSA<T extends Chromosome> extends DynaMOSA<T> {
         if (this.goalsManager.getCurrentGoals().size() == 0) {
             // trigger point to include non-buggy goals
             this.triggerFired = true;
-            goalsManager.updateCurrentGoals();
-            goalsManager.updateUncoveredGoals();
-            goalsManager.updateMethods();
-            goalsManager.updateBranchCoverageMaps();
+            updateGoalsManager();
 
             LoggingUtils.getEvoLogger().info(
-                    "Trigger to include non-buggy goals fired at {} seconds after {} generations",
+                    "* Trigger to include non-buggy goals fired at {} seconds after {} generations",
                     (int) (this.getCurrentTime() / 1000), this.currentIteration);
-            LoggingUtils.getEvoLogger().info("Trigger cause: No buggy goals");
+            LoggingUtils.getEvoLogger().info("* Trigger cause: No buggy goals");
         }
 
         LoggingUtils.getEvoLogger().info("* Initial Number of Goals in DynMOSA = " +
@@ -292,20 +289,19 @@ public class PreMOSA<T extends Chromosome> extends DynaMOSA<T> {
 
         this.currentUncoveredGoals = goalsManager.getUncoveredGoals().size();
 
-        if (zeroGoalsCovered) {
+        if (this.zeroGoalsCovered) {
             if (goalsManager.getCoveredGoals().size() > 0) {
-                zeroGoalsCovered = false;
+                this.zeroGoalsCovered = false;
             }
         }
 
         // next generations
-        while (!isFinished() /*&& this.goalsManager.getUncoveredGoals().size() > 0*/) {
+        while (!isFinished()) {
             this.evolve();
             this.notifyIteration();
         }
 
-        LoggingUtils.getEvoLogger().info("Adjust Goals Overhead: {} ms",
-                (double) (this.adjustGoalsOH) / 1000000);
+        LoggingUtils.getEvoLogger().info("* Adjust Goals Overhead: {} ms", (double) (this.adjustGoalsOH) / 1000000);
 
         this.notifySearchFinished();
     }

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/PreMOSA.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/PreMOSA.java
@@ -53,9 +53,6 @@ public class PreMOSA<T extends Chromosome> extends DynaMOSA<T> {
 
     private static final Logger logger = LoggerFactory.getLogger(PreMOSA.class);
 
-    /** Manager to determine the test goals to consider at each generation */
-    protected PredictiveCriteriaManager<T> goalsManager = null;
-
     /** Total time taken to adjust the goals (switch on/off goals) in nano seconds */
     private long adjustGoalsOH = 0;
 
@@ -156,43 +153,6 @@ public class PreMOSA<T extends Chromosome> extends DynaMOSA<T> {
     }
 
     /**
-     * Switch on/off current goals to balance test coverage among goals based on number of tests per an independent
-     * path of each goal
-     */
-    private void adjustCurrentGoals() {
-        for (int actualBranchId : this.goalsManager.getBranchCoverageTrueMap().keySet()) {
-            FitnessFunction ffTrue = this.goalsManager.getBranchCoverageTrueMap().get(actualBranchId);
-            FitnessFunction ffFalse = this.goalsManager.getBranchCoverageFalseMap().get(actualBranchId);
-
-            int numTestsTrueBranch = this.goalsManager.getNumTests(ffTrue.toString());
-            int numTestsFalseBranch = this.goalsManager.getNumTests(ffFalse.toString());
-
-            logger.debug("Branch: {}, Number of Tests: {}, Num of Paths: {}", ffTrue.toString(), numTestsTrueBranch,
-                    this.goalsManager.getNumPathsFor(ffTrue));
-            logger.debug("Branch: {}, Number of Tests: {}, Num of Paths: {}", ffFalse.toString(), numTestsFalseBranch,
-                    this.goalsManager.getNumPathsFor(ffFalse));
-
-            if (numTestsTrueBranch == 0 && numTestsFalseBranch == 0) {
-                continue;
-            }
-
-            int numPathsTrueBranch = this.goalsManager.getNumPathsFor(ffTrue);
-            int numPathsFalseBranch = this.goalsManager.getNumPathsFor(ffFalse);
-
-            double testsPerPathTrueB = (double) numTestsTrueBranch / numPathsTrueBranch;
-            double testsPerPathFalseB = (double) numTestsFalseBranch / numPathsFalseBranch;
-
-            if (Double.compare(testsPerPathTrueB, testsPerPathFalseB) > 0) {
-                this.goalsManager.getCurrentGoals().remove(ffTrue);
-                this.goalsManager.getCurrentGoals().add(ffFalse);
-            } else if (Double.compare(testsPerPathTrueB, testsPerPathFalseB) < 0) {
-                this.goalsManager.getCurrentGoals().remove(ffFalse);
-                this.goalsManager.getCurrentGoals().add(ffTrue);
-            }
-        }
-    }
-
-    /**
      * Add non-buggy goals to the search if number of consecutive iterations without buggy goals coverage improvement
      * is \geq org.evosuite.Properties.ITERATIONS_WO_IMPROVEMENT or if no buggy goal is covered for
      * org.evosuite.Properties.ZERO_COVERAGE_TRIGGER
@@ -245,10 +205,11 @@ public class PreMOSA<T extends Chromosome> extends DynaMOSA<T> {
      * Update goals manager after the trigger is fired to include non-buggy goals in the search
      */
     private void updateGoalsManager() {
-        goalsManager.updateCurrentGoals();
-        goalsManager.updateUncoveredGoals();
-        goalsManager.updateMethods();
-        goalsManager.updateBranchCoverageMaps();
+        // TODO: Currently using down-casting -> Fix that
+        ((PredictiveCriteriaManager) goalsManager).updateCurrentGoals();
+        ((PredictiveCriteriaManager) goalsManager).updateUncoveredGoals();
+        ((PredictiveCriteriaManager) goalsManager).updateMethods();
+        ((PredictiveCriteriaManager) goalsManager).updateBranchCoverageMaps();
     }
 
     /**

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/PreMOSA.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/PreMOSA.java
@@ -1,0 +1,316 @@
+/**
+ * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
+ * contributors
+ *
+ * This file is part of EvoSuite.
+ *
+ * EvoSuite is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * EvoSuite is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.evosuite.ga.metaheuristics.mosa;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+import org.evosuite.Properties;
+import org.evosuite.coverage.branch.BranchCoverageTestFitness;
+import org.evosuite.ga.Chromosome;
+import org.evosuite.ga.ChromosomeFactory;
+import org.evosuite.ga.FitnessFunction;
+import org.evosuite.ga.comparators.OnlyCrowdingComparator;
+import org.evosuite.ga.metaheuristics.mosa.structural.MultiCriteriatManager;
+import org.evosuite.ga.metaheuristics.mosa.structural.StructuralGoalManager;
+import org.evosuite.ga.operators.ranking.CrowdingDistance;
+import org.evosuite.testcase.TestChromosome;
+import org.evosuite.testsuite.TestSuiteChromosome;
+import org.evosuite.testsuite.TestSuiteFitnessFunction;
+import org.evosuite.utils.LoggingUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of PreMOSA (Predictive Many Objective Sorting Algorithm) described in the paper
+ * "Guiding Search-Based Software Testing with Defect Prediction Information".
+ *
+ * @author Anjana Perera
+ */
+public class PreMOSA<T extends Chromosome> extends DynaMOSA<T> {
+
+    private static final long serialVersionUID = 146182080947267628L;
+
+    private static final Logger logger = LoggerFactory.getLogger(PreMOSA.class);
+
+    /** Total time taken to adjust the goals (switch on/off goals) in nano seconds */
+    private long adjustGoalsOH = 0;
+
+    /** Number of current consecutive iterations without coverage improvement */
+    private int currentIterationsWoImprovements = 0;
+
+    /** Current number of uncovered goals */
+    private int currentUncoveredGoals = 0;
+
+    /** If trigger to include non-buggy targets fired */
+    private boolean triggerFired = false;
+
+    /** If number of covered goals is zero */
+    private boolean zeroGoalsCovered = true;
+
+    /**
+     * Constructor based on the abstract class {@link AbstractMOSA}.
+     *
+     * @param factory
+     */
+    public PreMOSA(ChromosomeFactory<T> factory) {
+        super(factory);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected void evolve() {
+        List<T> offspringPopulation = this.breedNextGeneration();
+
+        // Create the union of parents and offSpring
+        List<T> union = new ArrayList<T>(this.population.size() + offspringPopulation.size());
+        union.addAll(this.population);
+        union.addAll(offspringPopulation);
+
+        // Ranking the union
+        logger.debug("Union Size = {}", union.size());
+
+        // Switch off targets to balance test coverage
+        long adjustGoalsStartTime = System.nanoTime();
+        adjustCurrentGoals(false);
+        long adjustGoalEndTime = System.nanoTime();
+
+        this.adjustGoalsOH += adjustGoalEndTime - adjustGoalsStartTime;
+
+        // Ranking the union using the best rank algorithm (modified version of the non dominated sorting algorithm
+        this.rankingFunction.computeRankingAssignment(union, this.goalsManager.getCurrentGoals());
+
+        // let's form the next population using "preference sorting and non-dominated sorting" on the
+        // updated set of goals
+        int remain = Math.max(Properties.POPULATION, this.rankingFunction.getSubfront(0).size());
+        int index = 0;
+        List<T> front = null;
+        this.population.clear();
+
+        // Obtain the next front
+        front = this.rankingFunction.getSubfront(index);
+
+        if (front.isEmpty()) {	// zero front is empty
+            index++;
+            front = this.rankingFunction.getSubfront(index);
+        }
+
+        while ((remain > 0) && (remain >= front.size()) && !front.isEmpty()) {
+            // Assign crowding distance to individuals
+            this.distance.fastEpsilonDominanceAssignment(front, this.goalsManager.getCurrentGoals());
+
+            // Add the individuals of this front
+            this.population.addAll(front);
+
+            // Decrement remain
+            remain = remain - front.size();
+
+            // Obtain the next front
+            index++;
+            if (remain > 0) {
+                front = this.rankingFunction.getSubfront(index);
+            }
+        }
+
+        // Remain is less than front(index).size, insert only the best one
+        if (remain > 0 && !front.isEmpty()) { // front contains individuals to insert
+            this.distance.fastEpsilonDominanceAssignment(front, this.goalsManager.getCurrentGoals());
+            Collections.sort(front, new OnlyCrowdingComparator());
+            for (int k = 0; k < remain; k++) {
+                this.population.add(front.get(k));
+            }
+
+            remain = 0;
+        }
+
+        this.currentIteration++;
+
+        if (!triggerFired) {
+            if (goalsManager.getUncoveredGoals().size() == this.currentUncoveredGoals) {
+                this.currentIterationsWoImprovements++;
+            } else {
+                this.currentUncoveredGoals = goalsManager.getUncoveredGoals().size();
+                this.currentIterationsWoImprovements = 0;
+            }
+
+            if (this.currentIterationsWoImprovements >= Properties.ITERATIONS_WO_IMPROVEMENT) {
+                // trigger point to include non-buggy goals
+                this.triggerFired = true;
+                goalsManager.updateCurrentGoals();
+                goalsManager.updateUncoveredGoals();
+                goalsManager.updateMethods();
+                goalsManager.updateBranchCoverageMaps();
+
+                LoggingUtils.getEvoLogger().info(
+                        "Trigger to include non-buggy goals fired at {} seconds after {} generations",
+                        (int) (this.getCurrentTime() / 1000), this.currentIteration);
+                LoggingUtils.getEvoLogger().info(
+                        "Trigger cause: Buggy goals coverage is not improved for {} generations, current uncovered goals {}",
+                        this.currentIterationsWoImprovements, this.currentUncoveredGoals);
+            }
+        }
+
+        if (zeroGoalsCovered) {
+            if (goalsManager.getCoveredGoals().size() > 0) {
+                zeroGoalsCovered = false;
+            }
+        }
+
+        if (zeroGoalsCovered && !triggerFired) {
+            if (this.currentIteration >= Properties.ZERO_COVERAGE_TRIGGER) {
+                this.triggerFired = true;
+                goalsManager.updateCurrentGoals();
+                goalsManager.updateUncoveredGoals();
+                goalsManager.updateMethods();
+                goalsManager.updateBranchCoverageMaps();
+
+                LoggingUtils.getEvoLogger().info(
+                        "Trigger to include non-buggy goals fired at {} seconds after {} generations",
+                        (int) (this.getCurrentTime() / 1000), this.currentIteration);
+                LoggingUtils.getEvoLogger().info(
+                        "Trigger cause: Buggy goals coverage is zero for {} generations, current uncovered goals {}",
+                        this.currentIteration, this.currentUncoveredGoals);
+            }
+        }
+
+        logger.debug("Covered goals = {}", goalsManager.getCoveredGoals().size());
+        logger.debug("Current goals = {}", goalsManager.getCurrentGoals().size());
+        logger.debug("Uncovered goals = {}", goalsManager.getUncoveredGoals().size());
+    }
+
+    private void adjustCurrentGoals(boolean logInfo) {
+        for (int actualBranchId : this.goalsManager.getBranchCoverageTrueMap().keySet()) {
+            FitnessFunction ffTrue = this.goalsManager.getBranchCoverageTrueMap().get(actualBranchId);
+            FitnessFunction ffFalse = this.goalsManager.getBranchCoverageFalseMap().get(actualBranchId);
+
+            int numTestsTrueBranch = this.goalsManager.getNumTests(ffTrue.toString());
+            int numTestsFalseBranch = this.goalsManager.getNumTests(ffFalse.toString());
+
+            if (logInfo) {
+                LoggingUtils.getEvoLogger().info("Branch: {}, Number of Tests: {}, Num of Paths: {}", ffTrue.toString(),
+                        numTestsTrueBranch, this.goalsManager.getNumPathsFor(ffTrue));
+                LoggingUtils.getEvoLogger().info("Branch: {}, Number of Tests: {}, Num of Paths: {}", ffFalse.toString(),
+                        numTestsFalseBranch, this.goalsManager.getNumPathsFor(ffFalse));
+            }
+
+            if (numTestsTrueBranch == 0 && numTestsFalseBranch == 0) {
+                continue;
+            }
+
+            int numPathsTrueBranch = this.goalsManager.getNumPathsFor(ffTrue);
+            int numPathsFalseBranch = this.goalsManager.getNumPathsFor(ffFalse);
+
+            double testsPerPathTrueB = (double) numTestsTrueBranch / numPathsTrueBranch;
+            double testsPerPathFalseB = (double) numTestsFalseBranch / numPathsFalseBranch;
+
+            if (Double.compare(testsPerPathTrueB, testsPerPathFalseB) > 0) {
+                this.goalsManager.getCurrentGoals().remove(ffTrue);
+                this.goalsManager.getCurrentGoals().add(ffFalse);
+            } else if (Double.compare(testsPerPathTrueB, testsPerPathFalseB) < 0) {
+                this.goalsManager.getCurrentGoals().remove(ffFalse);
+                this.goalsManager.getCurrentGoals().add(ffTrue);
+            } else {
+                continue;
+            }
+
+			/*numTestsTrueBranch = numTestsTrueBranch == 0 ? 1 : numTestsTrueBranch;
+			numTestsFalseBranch = numTestsFalseBranch == 0 ? 1 : numTestsFalseBranch;
+
+			double scaleUpFactor = (double) numTestsTrueBranch / numTestsFalseBranch;
+			if (Double.compare(scaleUpFactor, 1.0) > 0) {	// True Branch has more tests
+				((BranchCoverageTestFitness) ffFalse).setNumTestCasesInZeroFront((int) Math.ceil(scaleUpFactor * 1));
+				// 1 - Default Num Test Cases in Zero Front
+				((BranchCoverageTestFitness) ffTrue).setNumTestCasesInZeroFront(0);
+			} else {	// False Branch has more tests
+				((BranchCoverageTestFitness) ffTrue).setNumTestCasesInZeroFront((int) Math.ceil(1 / scaleUpFactor));
+				// 1 - Default Num Test Cases in Zero Front
+				((BranchCoverageTestFitness) ffFalse).setNumTestCasesInZeroFront(0);
+			}*/
+
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void generateSolution() {
+        logger.debug("executing generateSolution function");
+
+        this.goalsManager = new MultiCriteriatManager<T>(this.fitnessFunctions);
+
+        if (this.goalsManager.getCurrentGoals().size() == 0) {
+            // trigger point to include non-buggy goals
+            this.triggerFired = true;
+            goalsManager.updateCurrentGoals();
+            goalsManager.updateUncoveredGoals();
+            goalsManager.updateMethods();
+            goalsManager.updateBranchCoverageMaps();
+
+            LoggingUtils.getEvoLogger().info(
+                    "Trigger to include non-buggy goals fired at {} seconds after {} generations",
+                    (int) (this.getCurrentTime() / 1000), this.currentIteration);
+            LoggingUtils.getEvoLogger().info("Trigger cause: No buggy goals");
+        }
+
+        LoggingUtils.getEvoLogger().info("* Initial Number of Goals in DynMOSA = " +
+                this.goalsManager.getCurrentGoals().size() +" / "+ this.getUncoveredGoals().size());
+
+        logger.debug("Initial Number of Goals = " + this.goalsManager.getCurrentGoals().size());
+
+        //initialize population
+        if (this.population.isEmpty()) {
+            this.initializePopulation();
+        }
+
+        // update current goals
+        this.calculateFitness();
+
+        // Calculate dominance ranks and crowding distance
+        this.rankingFunction.computeRankingAssignment(this.population, this.goalsManager.getCurrentGoals());
+
+        for (int i = 0; i < this.rankingFunction.getNumberOfSubfronts(); i++){
+            this.distance.fastEpsilonDominanceAssignment(this.rankingFunction.getSubfront(i), this.goalsManager.getCurrentGoals());
+        }
+
+        this.currentUncoveredGoals = goalsManager.getUncoveredGoals().size();
+
+        if (zeroGoalsCovered) {
+            if (goalsManager.getCoveredGoals().size() > 0) {
+                zeroGoalsCovered = false;
+            }
+        }
+
+        // next generations
+        while (!isFinished() /*&& this.goalsManager.getUncoveredGoals().size() > 0*/) {
+            this.evolve();
+            this.notifyIteration();
+        }
+
+        adjustCurrentGoals(true);
+        LoggingUtils.getEvoLogger().info("Adjust Goals Overhead: {} ms",
+                (double) (this.adjustGoalsOH) / 1000000);
+
+        this.notifySearchFinished();
+    }
+
+}

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/MultiCriteriatManager.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/MultiCriteriatManager.java
@@ -137,6 +137,10 @@ public class MultiCriteriatManager<T extends Chromosome> extends StructuralGoalM
 		this.currentGoals.addAll(graph.getRootBranches());
 
 		// Calculate number of independent paths leading up from each target (goal)
+		calculateIndependentPaths(fitnessFunctions);
+	}
+
+	protected void calculateIndependentPaths(List<FitnessFunction<T>> fitnessFunctions) {
 		long pathsCalculationStartTime = System.nanoTime();
 		for (FitnessFunction<T> rootBranch : graph.getRootBranches()) {
 			Set<FitnessFunction<T>> allParents = new HashSet<>();
@@ -184,7 +188,7 @@ public class MultiCriteriatManager<T extends Chromosome> extends StructuralGoalM
 	}
 
 	@SuppressWarnings("unchecked")
-	private void addDependencies4TryCatch() {
+	protected void addDependencies4TryCatch() {
 		logger.debug("Added dependencies for Try-Catch");
 		for (FitnessFunction<T> ff : this.uncoveredGoals){
 			if (ff instanceof TryCatchCoverageTestFitness){
@@ -195,7 +199,7 @@ public class MultiCriteriatManager<T extends Chromosome> extends StructuralGoalM
 		}
 	}
 
-	private void initializeMaps(Set<FitnessFunction<T>> set){
+	protected void initializeMaps(Set<FitnessFunction<T>> set){
 		for (FitnessFunction<T> ff : set) {
 			BranchCoverageTestFitness goal = (BranchCoverageTestFitness) ff;
 			// Skip instrumented branches - we only want real branches
@@ -217,7 +221,7 @@ public class MultiCriteriatManager<T extends Chromosome> extends StructuralGoalM
 		}
 	}
 
-	private void addDependencies4Output() {
+	protected void addDependencies4Output() {
 		logger.debug("Added dependencies for Output");
 		for (FitnessFunction<T> ff : this.uncoveredGoals){
 			if (ff instanceof OutputCoverageTestFitness){
@@ -249,7 +253,7 @@ public class MultiCriteriatManager<T extends Chromosome> extends StructuralGoalM
 	 * This methods derive the dependencies between {@link InputCoverageTestFitness} and branches. 
 	 * Therefore, it is used to update 'this.dependencies'
 	 */
-	private void addDependencies4Input() {
+	protected void addDependencies4Input() {
 		logger.debug("Added dependencies for Input");
 		for (FitnessFunction<T> ff : this.uncoveredGoals){
 			if (ff instanceof InputCoverageTestFitness){
@@ -278,11 +282,11 @@ public class MultiCriteriatManager<T extends Chromosome> extends StructuralGoalM
 	}
 
 	/**
-	 * This methods derive the dependencies between {@link MethodCoverageTestFitness} and branches. 
+	 * This methods derive the dependencies between {@link MethodCoverageTestFitness} and branches.
 	 * Therefore, it is used to update 'this.dependencies'
 	 */
 	@SuppressWarnings("unchecked")
-	private void addDependencies4Methods() {
+	protected void addDependencies4Methods() {
 		logger.debug("Added dependencies for Methods");
 		for (BranchCoverageTestFitness branch : this.dependencies.keySet()){
 			MethodCoverageTestFitness method = new MethodCoverageTestFitness(branch.getClassName(), branch.getMethod());
@@ -295,7 +299,7 @@ public class MultiCriteriatManager<T extends Chromosome> extends StructuralGoalM
 	 * Therefore, it is used to update 'this.dependencies'
 	 */
 	@SuppressWarnings("unchecked")
-	private void addDependencies4MethodsNoException() {
+	protected void addDependencies4MethodsNoException() {
 		logger.debug("Added dependencies for MethodsNoException");
 		for (BranchCoverageTestFitness branch : this.dependencies.keySet()){
 			MethodNoExceptionCoverageTestFitness method = new MethodNoExceptionCoverageTestFitness(branch.getClassName(), branch.getMethod());
@@ -308,7 +312,7 @@ public class MultiCriteriatManager<T extends Chromosome> extends StructuralGoalM
 	 * Therefore, it is used to update 'this.dependencies'
 	 */
 	@SuppressWarnings("unchecked")
-	private void addDependencies4CBranch() {
+	protected void addDependencies4CBranch() {
 		logger.debug("Added dependencies for CBranch");
 		CallGraph callGraph = DependencyAnalysis.getCallGraph();
 		for (BranchCoverageTestFitness branch : this.dependencies.keySet()) {
@@ -324,7 +328,7 @@ public class MultiCriteriatManager<T extends Chromosome> extends StructuralGoalM
 	 * This methods derive the dependencies between {@link WeakMutationTestFitness} and branches. 
 	 * Therefore, it is used to update 'this.dependencies'
 	 */
-	private void addDependencies4WeakMutation() {
+	protected void addDependencies4WeakMutation() {
 		logger.debug("Added dependencies for Weak-Mutation");
 		for (FitnessFunction<T> ff : this.uncoveredGoals){
 			if (ff instanceof WeakMutationTestFitness){
@@ -346,7 +350,7 @@ public class MultiCriteriatManager<T extends Chromosome> extends StructuralGoalM
 	 * This methods derive the dependencies between {@link org.evosuite.coverage.mutation.StrongMutationTestFitness} and branches.
 	 * Therefore, it is used to update 'this.dependencies'
 	 */
-	private void addDependencies4StrongMutation() {
+	protected void addDependencies4StrongMutation() {
 		logger.debug("Added dependencies for Strong-Mutation");
 		for (FitnessFunction<T> ff : this.uncoveredGoals){
 			if (ff instanceof StrongMutationTestFitness){
@@ -368,7 +372,7 @@ public class MultiCriteriatManager<T extends Chromosome> extends StructuralGoalM
 	 * This methods derive the dependencies between  {@link LineCoverageTestFitness} and branches. 
 	 * Therefore, it is used to update 'this.dependencies'
 	 */
-	private void addDependencies4Line() {
+	protected void addDependencies4Line() {
 		logger.debug("Added dependencies for Lines");
 		for (FitnessFunction<T> ff : this.uncoveredGoals){
 			if (ff instanceof LineCoverageTestFitness){
@@ -394,7 +398,7 @@ public class MultiCriteriatManager<T extends Chromosome> extends StructuralGoalM
 	 * Therefore, it is used to update 'this.dependencies'
 	 */
 	@SuppressWarnings("unchecked")
-	private void addDependencies4Statement() {
+	protected void addDependencies4Statement() {
 		logger.debug("Added dependencies for Statements");
 		for (FitnessFunction<T> ff : this.uncoveredGoals){
 			if (ff instanceof StatementCoverageTestFitness){
@@ -409,8 +413,6 @@ public class MultiCriteriatManager<T extends Chromosome> extends StructuralGoalM
 			}
 		}
 	}
-
-
 
 	@SuppressWarnings("unchecked")
 	@Override

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/MultiCriteriatManager.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/MultiCriteriatManager.java
@@ -69,20 +69,30 @@ public class MultiCriteriatManager<T extends Chromosome> extends StructuralGoalM
 	protected Map<BranchCoverageTestFitness, Set<FitnessFunction<T>>> dependencies;
 
 	/** Number of independent paths leading up from each target (goal) */
-	protected Map<FitnessFunction<T>, Integer> numPaths = new LinkedHashMap<>();
+	protected Map<FitnessFunction<T>, Integer> numPaths;
 
 	/** Children of each target (goal) */
-	protected Map<FitnessFunction<T>, Set<FitnessFunction<T>>> children = new LinkedHashMap<>();
+	protected Map<FitnessFunction<T>, Set<FitnessFunction<T>>> children;
 
-	protected final Map<Integer, FitnessFunction<T>> branchCoverageTrueMap = new LinkedHashMap<Integer, FitnessFunction<T>>();
-	protected final Map<Integer, FitnessFunction<T>> branchCoverageFalseMap = new LinkedHashMap<Integer, FitnessFunction<T>>();
-	protected final Map<String, FitnessFunction<T>> branchlessMethodCoverageMap = new LinkedHashMap<String, FitnessFunction<T>>();
+	protected Map<Integer, FitnessFunction<T>> branchCoverageTrueMap;
+	protected Map<Integer, FitnessFunction<T>> branchCoverageFalseMap;
+	protected Map<String, FitnessFunction<T>> branchlessMethodCoverageMap;
 
 	public MultiCriteriatManager(List<FitnessFunction<T>> fitnessFunctions) {
 		super(fitnessFunctions);
+		instantiateAttributes();
+		init(fitnessFunctions);
 	}
 
-	@Override
+	protected void instantiateAttributes() {
+		numPaths = new LinkedHashMap<>();
+		children = new LinkedHashMap<>();
+
+		branchCoverageTrueMap = new LinkedHashMap<Integer, FitnessFunction<T>>();
+		branchCoverageFalseMap = new LinkedHashMap<Integer, FitnessFunction<T>>();
+		branchlessMethodCoverageMap = new LinkedHashMap<String, FitnessFunction<T>>();
+	}
+
 	protected void init(List<FitnessFunction<T>> fitnessFunctions) {
 		// initialize uncovered goals
 		uncoveredGoals.addAll(fitnessFunctions);

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/MultiCriteriatManager.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/MultiCriteriatManager.java
@@ -80,7 +80,6 @@ public class MultiCriteriatManager<T extends Chromosome> extends StructuralGoalM
 
 	public MultiCriteriatManager(List<FitnessFunction<T>> fitnessFunctions) {
 		super(fitnessFunctions);
-		init(fitnessFunctions);
 	}
 
 	@Override

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/MultiCriteriatManager.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/MultiCriteriatManager.java
@@ -568,4 +568,12 @@ public class MultiCriteriatManager<T extends Chromosome> extends StructuralGoalM
     public int getNumPathsFor(FitnessFunction<T> ff) {
 		return this.numPaths.get(ff);
 	}
+
+	public Map<Integer, FitnessFunction<T>> getBranchCoverageTrueMap() {
+		return branchCoverageTrueMap;
+	}
+
+	public Map<Integer, FitnessFunction<T>> getBranchCoverageFalseMap() {
+		return branchCoverageFalseMap;
+	}
 }

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/MultiCriteriatManager.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/MultiCriteriatManager.java
@@ -146,8 +146,10 @@ public class MultiCriteriatManager<T extends Chromosome> extends StructuralGoalM
 		// initialize current goals
 		this.currentGoals.addAll(graph.getRootBranches());
 
-		// Calculate number of independent paths leading up from each target (goal)
-		calculateIndependentPaths(fitnessFunctions);
+		if (Properties.BALANCE_TEST_COV) {
+			// Calculate number of independent paths leading up from each target (goal)
+			calculateIndependentPaths(fitnessFunctions);
+		}
 	}
 
 	protected void calculateIndependentPaths(List<FitnessFunction<T>> fitnessFunctions) {

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/MultiCriteriatManager.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/MultiCriteriatManager.java
@@ -68,54 +68,24 @@ public class MultiCriteriatManager<T extends Chromosome> extends StructuralGoalM
 
 	protected Map<BranchCoverageTestFitness, Set<FitnessFunction<T>>> dependencies;
 
-	private Set<MethodCoverageTestFitness> methods;
-	private Set<MethodCoverageTestFitness> nonBuggyMethods = new HashSet<>();;
-
+	/** Number of independent paths leading up from each target (goal) */
 	private Map<FitnessFunction<T>, Integer> numPaths = new LinkedHashMap<>();
-	private Map<FitnessFunction<T>, Set<FitnessFunction<T>>> children = new LinkedHashMap<>();
 
-	private Set<FitnessFunction<T>> nonBuggyGoals;
+	/** Children of each target (goal) */
+	private Map<FitnessFunction<T>, Set<FitnessFunction<T>>> children = new LinkedHashMap<>();
 
 	protected final Map<Integer, FitnessFunction<T>> branchCoverageTrueMap = new LinkedHashMap<Integer, FitnessFunction<T>>();
 	protected final Map<Integer, FitnessFunction<T>> branchCoverageFalseMap = new LinkedHashMap<Integer, FitnessFunction<T>>();
 	private final Map<String, FitnessFunction<T>> branchlessMethodCoverageMap = new LinkedHashMap<String, FitnessFunction<T>>();
 
-	private final Map<Integer, FitnessFunction<T>> nBBranchCoverageTrueMap = new LinkedHashMap<Integer, FitnessFunction<T>>();
-	private final Map<Integer, FitnessFunction<T>> nBBranchCoverageFalseMap = new LinkedHashMap<Integer, FitnessFunction<T>>();
-	private final Map<String, FitnessFunction<T>> nBBranchlessMethodCoverageMap = new LinkedHashMap<String, FitnessFunction<T>>();
-
 	public MultiCriteriatManager(List<FitnessFunction<T>> fitnessFunctions) {
 		super(fitnessFunctions);
 
-		nonBuggyGoals = new HashSet<FitnessFunction<T>>(fitnessFunctions.size());
-
-		// initialize uncovered goals and find nonBuggyGoals
-		// uncoveredGoals.addAll(fitnessFunctions);
-		for (FitnessFunction<T> ff : fitnessFunctions) {
-			if (ff instanceof BranchCoverageTestFitness) {
-				if (((BranchCoverageTestFitness) ff).isBuggy()) {
-					uncoveredGoals.add(ff);
-				} else {
-					nonBuggyGoals.add(ff);
-				}
-			} else if (ff instanceof MethodCoverageTestFitness) {
-				if (((MethodCoverageTestFitness) ff).isBuggy()) {
-					uncoveredGoals.add(ff);
-				} else {
-					nonBuggyGoals.add(ff);
-				}
-			} else {
-				uncoveredGoals.add(ff);
-			}
-		}
-
-		LoggingUtils.getEvoLogger().info("* Total Number of Buggy Goals: " + uncoveredGoals.size());
-		LoggingUtils.getEvoLogger().info("* Total Number of Non-Buggy Goals: " + nonBuggyGoals.size());
+		// initialize uncovered goals
+		uncoveredGoals.addAll(fitnessFunctions);
 
 		// initialize the dependency graph among branches 
 		this.graph = getControlDepencies4Branches();
-
-		this.methods = getMethods(fitnessFunctions, this.nonBuggyMethods);
 
 		// initialize the dependency graph between branches and other coverage targets (e.g., statements)
 		// let's derive the dependency graph between branches and other coverage targets (e.g., statements)
@@ -161,13 +131,9 @@ public class MultiCriteriatManager<T extends Chromosome> extends StructuralGoalM
 		}
 
 		// initialize current goals
-		// this.currentGoals.addAll(graph.getRootBranches());
-		for (FitnessFunction<T> ff : graph.getRootBranches()) {
-			if (((BranchCoverageTestFitness) ff).isBuggy()) {
-				this.currentGoals.add(ff);
-			}
-		}
+		this.currentGoals.addAll(graph.getRootBranches());
 
+		// Calculate number of independent paths leading up from each target (goal)
 		long pathsCalculationStartTime = System.nanoTime();
 		for (FitnessFunction<T> rootBranch : graph.getRootBranches()) {
 			Set<FitnessFunction<T>> allParents = new HashSet<>();
@@ -186,24 +152,8 @@ public class MultiCriteriatManager<T extends Chromosome> extends StructuralGoalM
 			}
 		}
 		long pathsCalculationEndTime = System.nanoTime();
-		LoggingUtils.getEvoLogger().info("Paths Calculation Overhead: {} ms",
+		LoggingUtils.getEvoLogger().info("* Paths Calculation Overhead: {} ms",
 				(double) (pathsCalculationEndTime - pathsCalculationStartTime) / 1000000);
-	}
-
-	private Set<MethodCoverageTestFitness> getMethods(List<FitnessFunction<T>> fitnessFunctions,
-													  Set<MethodCoverageTestFitness> nonBuggyMethods) {
-		Set<MethodCoverageTestFitness> methods = new HashSet<>();
-		for (FitnessFunction<T> ff : fitnessFunctions) {
-			if (ff instanceof MethodCoverageTestFitness) {
-				if (((MethodCoverageTestFitness) ff).isBuggy()) {
-					methods.add((MethodCoverageTestFitness) ff);
-				} else {
-					nonBuggyMethods.add((MethodCoverageTestFitness) ff);
-				}
-			}
-		}
-
-		return methods;
 	}
 
 	private Integer calculateNumPaths(Set<FitnessFunction<T>> childrenOf) {
@@ -253,26 +203,12 @@ public class MultiCriteriatManager<T extends Chromosome> extends StructuralGoalM
 			}
 
 			if (goal.getBranch() == null) {
-				if (goal.isBuggy()) {
-					branchlessMethodCoverageMap.put(goal.getClassName() + "." + goal.getMethod(), ff);
-				} else {
-					nBBranchlessMethodCoverageMap.put(goal.getClassName() + "." + goal.getMethod(), ff);
-				}
+				branchlessMethodCoverageMap.put(goal.getClassName() + "." + goal.getMethod(), ff);
 			} else {
-				if (goal.isBuggy()) {
-					if (goal.getBranchExpressionValue()) {
-						branchCoverageTrueMap.put(goal.getBranch().getActualBranchId(), ff);
-					}
-					else {
-						branchCoverageFalseMap.put(goal.getBranch().getActualBranchId(), ff);
-					}
+				if (goal.getBranchExpressionValue()) {
+					branchCoverageTrueMap.put(goal.getBranch().getActualBranchId(), ff);
 				} else {
-					if (goal.getBranchExpressionValue()) {
-						nBBranchCoverageTrueMap.put(goal.getBranch().getActualBranchId(), ff);
-					}
-					else {
-						nBBranchCoverageFalseMap.put(goal.getBranch().getActualBranchId(), ff);
-					}
+					branchCoverageFalseMap.put(goal.getBranch().getActualBranchId(), ff);
 				}
 			}
 		}
@@ -488,8 +424,6 @@ public class MultiCriteriatManager<T extends Chromosome> extends StructuralGoalM
 			return;
 		}
 
-		Set<MethodCoverageTestFitness> visitedMethods = new HashSet<>();
-
 		// 1) we update the set of currents goals
 		Set<FitnessFunction<T>> visitedTargets = new LinkedHashSet<FitnessFunction<T>>(uncoveredGoals.size()*2);
 		LinkedList<FitnessFunction<T>> targets = new LinkedList<FitnessFunction<T>>();
@@ -505,10 +439,6 @@ public class MultiCriteriatManager<T extends Chromosome> extends StructuralGoalM
 
 			double value = fitnessFunction.getFitness(c);
 			if (value == 0.0) {
-				if (fitnessFunction instanceof MethodCoverageTestFitness) {
-					visitedMethods.add((MethodCoverageTestFitness) fitnessFunction);
-				}
-
 				updateCoveredGoals(fitnessFunction, c);
 				if (fitnessFunction instanceof BranchCoverageTestFitness){
 					for (FitnessFunction<T> child : graph.getStructuralChildren(fitnessFunction)){
@@ -559,18 +489,6 @@ public class MultiCriteriatManager<T extends Chromosome> extends StructuralGoalM
 				}
 			}
 		}
-
-		if (ArrayUtil.contains(Properties.CRITERION, METHOD)){
-			for (MethodCoverageTestFitness methodFf : this.methods) {
-				if (!visitedMethods.contains(methodFf)) {
-					double value = ((FitnessFunction) methodFf).getFitness(c);
-					if (value == 0.0) {
-						updateCoveredGoals((FitnessFunction) methodFf, c);
-					}
-				}
-			}
-		}
-
 	}
 
 	/**
@@ -632,37 +550,7 @@ public class MultiCriteriatManager<T extends Chromosome> extends StructuralGoalM
 		return new BranchFitnessGraph<T, FitnessFunction<T>>(setOfBranches);
 	}
 
-    public Map<Integer, FitnessFunction<T>> getBranchCoverageTrueMap() {
-        return branchCoverageTrueMap;
-    }
-
-    public Map<Integer, FitnessFunction<T>> getBranchCoverageFalseMap() {
-        return branchCoverageFalseMap;
-    }
-
     public int getNumPathsFor(FitnessFunction<T> ff) {
 		return this.numPaths.get(ff);
-	}
-
-	public void updateCurrentGoals() {
-		for (FitnessFunction<T> ff : graph.getRootBranches()) {
-			if (!((BranchCoverageTestFitness) ff).isBuggy()) {
-				this.currentGoals.add(ff);
-			}
-		}
-	}
-
-	public void updateUncoveredGoals() {
-		this.uncoveredGoals.addAll(this.nonBuggyGoals);
-	}
-
-	public void updateMethods() {
-		this.methods.addAll(this.nonBuggyMethods);
-	}
-
-	public void updateBranchCoverageMaps() {
-		branchCoverageTrueMap.putAll(nBBranchCoverageTrueMap);
-		branchCoverageFalseMap.putAll(nBBranchCoverageFalseMap);
-		branchlessMethodCoverageMap.putAll(nBBranchlessMethodCoverageMap);
 	}
 }

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/MultiCriteriatManager.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/MultiCriteriatManager.java
@@ -69,22 +69,26 @@ public class MultiCriteriatManager<T extends Chromosome> extends StructuralGoalM
 	protected Map<BranchCoverageTestFitness, Set<FitnessFunction<T>>> dependencies;
 
 	/** Number of independent paths leading up from each target (goal) */
-	private Map<FitnessFunction<T>, Integer> numPaths = new LinkedHashMap<>();
+	protected Map<FitnessFunction<T>, Integer> numPaths = new LinkedHashMap<>();
 
 	/** Children of each target (goal) */
-	private Map<FitnessFunction<T>, Set<FitnessFunction<T>>> children = new LinkedHashMap<>();
+	protected Map<FitnessFunction<T>, Set<FitnessFunction<T>>> children = new LinkedHashMap<>();
 
 	protected final Map<Integer, FitnessFunction<T>> branchCoverageTrueMap = new LinkedHashMap<Integer, FitnessFunction<T>>();
 	protected final Map<Integer, FitnessFunction<T>> branchCoverageFalseMap = new LinkedHashMap<Integer, FitnessFunction<T>>();
-	private final Map<String, FitnessFunction<T>> branchlessMethodCoverageMap = new LinkedHashMap<String, FitnessFunction<T>>();
+	protected final Map<String, FitnessFunction<T>> branchlessMethodCoverageMap = new LinkedHashMap<String, FitnessFunction<T>>();
 
 	public MultiCriteriatManager(List<FitnessFunction<T>> fitnessFunctions) {
 		super(fitnessFunctions);
+		init(fitnessFunctions);
+	}
 
+	@Override
+	protected void init(List<FitnessFunction<T>> fitnessFunctions) {
 		// initialize uncovered goals
 		uncoveredGoals.addAll(fitnessFunctions);
 
-		// initialize the dependency graph among branches 
+		// initialize the dependency graph among branches
 		this.graph = getControlDepencies4Branches();
 
 		// initialize the dependency graph between branches and other coverage targets (e.g., statements)

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/PredictiveCriteriaManager.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/PredictiveCriteriaManager.java
@@ -1,0 +1,668 @@
+/**
+ * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
+ * contributors
+ *
+ * This file is part of EvoSuite.
+ *
+ * EvoSuite is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * EvoSuite is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.evosuite.ga.metaheuristics.mosa.structural;
+
+import java.util.*;
+
+import org.evosuite.Properties;
+import org.evosuite.TestGenerationContext;
+import org.evosuite.Properties.Criterion;
+import org.evosuite.coverage.branch.Branch;
+import org.evosuite.coverage.branch.BranchCoverageFactory;
+import org.evosuite.coverage.branch.BranchCoverageGoal;
+import org.evosuite.coverage.branch.BranchCoverageTestFitness;
+import org.evosuite.coverage.cbranch.CBranchTestFitness;
+import org.evosuite.coverage.exception.ExceptionCoverageFactory;
+import org.evosuite.coverage.exception.ExceptionCoverageHelper;
+import org.evosuite.coverage.exception.ExceptionCoverageTestFitness;
+import org.evosuite.coverage.exception.TryCatchCoverageTestFitness;
+import org.evosuite.coverage.io.input.InputCoverageTestFitness;
+import org.evosuite.coverage.io.output.OutputCoverageTestFitness;
+import org.evosuite.coverage.line.LineCoverageTestFitness;
+import org.evosuite.coverage.method.MethodCoverageTestFitness;
+import org.evosuite.coverage.method.MethodNoExceptionCoverageTestFitness;
+import org.evosuite.coverage.mutation.StrongMutationTestFitness;
+import org.evosuite.coverage.mutation.WeakMutationTestFitness;
+import org.evosuite.coverage.statement.StatementCoverageTestFitness;
+import org.evosuite.ga.Chromosome;
+import org.evosuite.ga.FitnessFunction;
+import org.evosuite.graphs.cfg.BytecodeInstruction;
+import org.evosuite.graphs.cfg.BytecodeInstructionPool;
+import org.evosuite.graphs.cfg.ControlDependency;
+import org.evosuite.setup.CallContext;
+import org.evosuite.setup.DependencyAnalysis;
+import org.evosuite.setup.callgraph.CallGraph;
+import org.evosuite.testcase.TestCase;
+import org.evosuite.testcase.TestChromosome;
+import org.evosuite.testcase.execution.ExecutionResult;
+import org.evosuite.testcase.execution.TestCaseExecutor;
+import org.evosuite.utils.ArrayUtil;
+import org.evosuite.utils.LoggingUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.evosuite.Properties.Criterion.*;
+
+public class PredictiveCriteriaManager<T extends Chromosome> extends MultiCriteriatManager<T>{
+
+    private static final Logger logger = LoggerFactory.getLogger(PredictiveCriteriaManager.class);
+
+    protected BranchFitnessGraph<T, FitnessFunction<T>> graph;
+
+    protected Map<BranchCoverageTestFitness, Set<FitnessFunction<T>>> dependencies;
+
+    private Set<MethodCoverageTestFitness> methods;
+    private Set<MethodCoverageTestFitness> nonBuggyMethods = new HashSet<>();;
+
+    private Map<FitnessFunction<T>, Integer> numPaths = new LinkedHashMap<>();
+    private Map<FitnessFunction<T>, Set<FitnessFunction<T>>> children = new LinkedHashMap<>();
+
+    private Set<FitnessFunction<T>> nonBuggyGoals;
+
+    protected final Map<Integer, FitnessFunction<T>> branchCoverageTrueMap = new LinkedHashMap<Integer, FitnessFunction<T>>();
+    protected final Map<Integer, FitnessFunction<T>> branchCoverageFalseMap = new LinkedHashMap<Integer, FitnessFunction<T>>();
+    private final Map<String, FitnessFunction<T>> branchlessMethodCoverageMap = new LinkedHashMap<String, FitnessFunction<T>>();
+
+    private final Map<Integer, FitnessFunction<T>> nBBranchCoverageTrueMap = new LinkedHashMap<Integer, FitnessFunction<T>>();
+    private final Map<Integer, FitnessFunction<T>> nBBranchCoverageFalseMap = new LinkedHashMap<Integer, FitnessFunction<T>>();
+    private final Map<String, FitnessFunction<T>> nBBranchlessMethodCoverageMap = new LinkedHashMap<String, FitnessFunction<T>>();
+
+    public PredictiveCriteriaManager(List<FitnessFunction<T>> fitnessFunctions) {
+        super(fitnessFunctions);
+
+        nonBuggyGoals = new HashSet<FitnessFunction<T>>(fitnessFunctions.size());
+
+        // initialize uncovered goals and find nonBuggyGoals
+        // uncoveredGoals.addAll(fitnessFunctions);
+        for (FitnessFunction<T> ff : fitnessFunctions) {
+            if (ff instanceof BranchCoverageTestFitness) {
+                if (((BranchCoverageTestFitness) ff).isBuggy()) {
+                    uncoveredGoals.add(ff);
+                } else {
+                    nonBuggyGoals.add(ff);
+                }
+            } else if (ff instanceof MethodCoverageTestFitness) {
+                if (((MethodCoverageTestFitness) ff).isBuggy()) {
+                    uncoveredGoals.add(ff);
+                } else {
+                    nonBuggyGoals.add(ff);
+                }
+            } else {
+                uncoveredGoals.add(ff);
+            }
+        }
+
+        LoggingUtils.getEvoLogger().info("* Total Number of Buggy Goals: " + uncoveredGoals.size());
+        LoggingUtils.getEvoLogger().info("* Total Number of Non-Buggy Goals: " + nonBuggyGoals.size());
+
+        // initialize the dependency graph among branches
+        this.graph = getControlDepencies4Branches();
+
+        this.methods = getMethods(fitnessFunctions, this.nonBuggyMethods);
+
+        // initialize the dependency graph between branches and other coverage targets (e.g., statements)
+        // let's derive the dependency graph between branches and other coverage targets (e.g., statements)
+        for (Criterion criterion : Properties.CRITERION){
+            switch (criterion){
+                case BRANCH:
+                    break; // branches have been handled by getControlDepencies4Branches
+                case EXCEPTION:
+                    break; // exception coverage is handled by calculateFitness
+                case LINE:
+                    addDependencies4Line();
+                    break;
+                case STATEMENT:
+                    addDependencies4Statement();
+                    break;
+                case WEAKMUTATION:
+                    addDependencies4WeakMutation();
+                    break;
+                case STRONGMUTATION:
+                    addDependencies4StrongMutation();
+                    break;
+                case METHOD:
+                    addDependencies4Methods();
+                    break;
+                case INPUT:
+                    addDependencies4Input();
+                    break;
+                case OUTPUT:
+                    addDependencies4Output();
+                    break;
+                case TRYCATCH:
+                    addDependencies4TryCatch();
+                    break;
+                case METHODNOEXCEPTION:
+                    addDependencies4MethodsNoException();
+                    break;
+                case CBRANCH:
+                    addDependencies4CBranch();
+                    break;
+                default:
+                    LoggingUtils.getEvoLogger().error("The criterion {} is not currently supported in DynaMOSA", criterion.name());
+            }
+        }
+
+        // initialize current goals
+        // this.currentGoals.addAll(graph.getRootBranches());
+        for (FitnessFunction<T> ff : graph.getRootBranches()) {
+            if (((BranchCoverageTestFitness) ff).isBuggy()) {
+                this.currentGoals.add(ff);
+            }
+        }
+
+        long pathsCalculationStartTime = System.nanoTime();
+        for (FitnessFunction<T> rootBranch : graph.getRootBranches()) {
+            Set<FitnessFunction<T>> allParents = new HashSet<>();
+            graph.getAllStructuralChildren(rootBranch, this.children, allParents);
+        }
+
+        for (FitnessFunction<T> ff : fitnessFunctions) {
+            if (ff instanceof BranchCoverageTestFitness) {
+                if (!this.children.containsKey(ff)) {
+                    logger.error("Children not found for {}", ff.toString());
+                    Set<FitnessFunction<T>> allParents = new HashSet<>();
+                    graph.getAllStructuralChildren(ff, this.children, allParents);
+                }
+
+                this.numPaths.put(ff, calculateNumPaths(this.children.get(ff)));
+            }
+        }
+        long pathsCalculationEndTime = System.nanoTime();
+        LoggingUtils.getEvoLogger().info("Paths Calculation Overhead: {} ms",
+                (double) (pathsCalculationEndTime - pathsCalculationStartTime) / 1000000);
+    }
+
+    private Set<MethodCoverageTestFitness> getMethods(List<FitnessFunction<T>> fitnessFunctions,
+                                                      Set<MethodCoverageTestFitness> nonBuggyMethods) {
+        Set<MethodCoverageTestFitness> methods = new HashSet<>();
+        for (FitnessFunction<T> ff : fitnessFunctions) {
+            if (ff instanceof MethodCoverageTestFitness) {
+                if (((MethodCoverageTestFitness) ff).isBuggy()) {
+                    methods.add((MethodCoverageTestFitness) ff);
+                } else {
+                    nonBuggyMethods.add((MethodCoverageTestFitness) ff);
+                }
+            }
+        }
+
+        return methods;
+    }
+
+    private Integer calculateNumPaths(Set<FitnessFunction<T>> childrenOf) {
+        Map<Branch, Integer> numChildren = new HashMap<>();
+        Set<Branch> cdNodes = new HashSet<>();
+
+        for (FitnessFunction<T> ff : childrenOf) {
+            Branch branch = ((BranchCoverageTestFitness) ff).getBranch();
+            if (numChildren.containsKey(branch)) {
+                int numChildrenForB = numChildren.get(branch);
+                numChildrenForB++;
+                numChildren.put(branch, numChildrenForB);
+
+                if (numChildrenForB == 2) {
+                    cdNodes.add(branch);
+                } else if (numChildrenForB > 2) {
+                    logger.error("Unexpected number of children for {}", branch.toString());
+                }
+            } else {
+                numChildren.put(branch, 1);
+            }
+        }
+
+        return cdNodes.size() + 1;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void addDependencies4TryCatch() {
+        logger.debug("Added dependencies for Try-Catch");
+        for (FitnessFunction<T> ff : this.uncoveredGoals){
+            if (ff instanceof TryCatchCoverageTestFitness){
+                TryCatchCoverageTestFitness stmt = (TryCatchCoverageTestFitness) ff;
+                BranchCoverageTestFitness branch = new BranchCoverageTestFitness(stmt.getBranchGoal());
+                this.dependencies.get(branch).add((FitnessFunction<T>) stmt);
+            }
+        }
+    }
+
+    private void initializeMaps(Set<FitnessFunction<T>> set){
+        for (FitnessFunction<T> ff : set) {
+            BranchCoverageTestFitness goal = (BranchCoverageTestFitness) ff;
+            // Skip instrumented branches - we only want real branches
+            if(goal.getBranch() != null) {
+                if(goal.getBranch().isInstrumented()) {
+                    continue;
+                }
+            }
+
+            if (goal.getBranch() == null) {
+                if (goal.isBuggy()) {
+                    branchlessMethodCoverageMap.put(goal.getClassName() + "." + goal.getMethod(), ff);
+                } else {
+                    nBBranchlessMethodCoverageMap.put(goal.getClassName() + "." + goal.getMethod(), ff);
+                }
+            } else {
+                if (goal.isBuggy()) {
+                    if (goal.getBranchExpressionValue()) {
+                        branchCoverageTrueMap.put(goal.getBranch().getActualBranchId(), ff);
+                    }
+                    else {
+                        branchCoverageFalseMap.put(goal.getBranch().getActualBranchId(), ff);
+                    }
+                } else {
+                    if (goal.getBranchExpressionValue()) {
+                        nBBranchCoverageTrueMap.put(goal.getBranch().getActualBranchId(), ff);
+                    }
+                    else {
+                        nBBranchCoverageFalseMap.put(goal.getBranch().getActualBranchId(), ff);
+                    }
+                }
+            }
+        }
+    }
+
+    private void addDependencies4Output() {
+        logger.debug("Added dependencies for Output");
+        for (FitnessFunction<T> ff : this.uncoveredGoals){
+            if (ff instanceof OutputCoverageTestFitness){
+                OutputCoverageTestFitness output = (OutputCoverageTestFitness) ff;
+                ClassLoader loader = TestGenerationContext.getInstance().getClassLoaderForSUT();
+                BytecodeInstructionPool pool = BytecodeInstructionPool.getInstance(loader);
+                if (pool.getInstructionsIn(output.getClassName(), output.getMethod()) == null){
+                    this.currentGoals.add(ff);
+                    continue;
+                }
+                for (BytecodeInstruction instruction : pool.getInstructionsIn(output.getClassName(), output.getMethod())) {
+                    if (instruction.getBasicBlock() != null){
+                        Set<ControlDependency> cds = instruction.getBasicBlock().getControlDependencies();
+                        if (cds.size()==0){
+                            this.currentGoals.add(ff);
+                        } else {
+                            for (ControlDependency cd : cds) {
+                                BranchCoverageTestFitness fitness = BranchCoverageFactory.createBranchCoverageTestFitness(cd);
+                                this.dependencies.get(fitness).add(ff);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * This methods derive the dependencies between {@link InputCoverageTestFitness} and branches.
+     * Therefore, it is used to update 'this.dependencies'
+     */
+    private void addDependencies4Input() {
+        logger.debug("Added dependencies for Input");
+        for (FitnessFunction<T> ff : this.uncoveredGoals){
+            if (ff instanceof InputCoverageTestFitness){
+                InputCoverageTestFitness input = (InputCoverageTestFitness) ff;
+                ClassLoader loader = TestGenerationContext.getInstance().getClassLoaderForSUT();
+                BytecodeInstructionPool pool = BytecodeInstructionPool.getInstance(loader);
+                if (pool.getInstructionsIn(input.getClassName(), input.getMethod()) == null) {
+                    this.currentGoals.add(ff);
+                    continue;
+                }
+                for (BytecodeInstruction instruction : pool.getInstructionsIn(input.getClassName(), input.getMethod())) {
+                    if (instruction.getBasicBlock() != null){
+                        Set<ControlDependency> cds = instruction.getBasicBlock().getControlDependencies();
+                        if (cds.size()==0){
+                            this.currentGoals.add(ff);
+                        } else {
+                            for (ControlDependency cd : cds) {
+                                BranchCoverageTestFitness fitness = BranchCoverageFactory.createBranchCoverageTestFitness(cd);
+                                this.dependencies.get(fitness).add(ff);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * This methods derive the dependencies between {@link MethodCoverageTestFitness} and branches.
+     * Therefore, it is used to update 'this.dependencies'
+     */
+    @SuppressWarnings("unchecked")
+    private void addDependencies4Methods() {
+        logger.debug("Added dependencies for Methods");
+        for (BranchCoverageTestFitness branch : this.dependencies.keySet()){
+            MethodCoverageTestFitness method = new MethodCoverageTestFitness(branch.getClassName(), branch.getMethod());
+            this.dependencies.get(branch).add((FitnessFunction<T>) method);
+        }
+    }
+
+    /**
+     * This methods derive the dependencies between {@link MethodNoExceptionCoverageTestFitness} and branches.
+     * Therefore, it is used to update 'this.dependencies'
+     */
+    @SuppressWarnings("unchecked")
+    private void addDependencies4MethodsNoException() {
+        logger.debug("Added dependencies for MethodsNoException");
+        for (BranchCoverageTestFitness branch : this.dependencies.keySet()){
+            MethodNoExceptionCoverageTestFitness method = new MethodNoExceptionCoverageTestFitness(branch.getClassName(), branch.getMethod());
+            this.dependencies.get(branch).add((FitnessFunction<T>) method);
+        }
+    }
+
+    /**
+     * This methods derive the dependencies between {@link CBranchTestFitness} and branches.
+     * Therefore, it is used to update 'this.dependencies'
+     */
+    @SuppressWarnings("unchecked")
+    private void addDependencies4CBranch() {
+        logger.debug("Added dependencies for CBranch");
+        CallGraph callGraph = DependencyAnalysis.getCallGraph();
+        for (BranchCoverageTestFitness branch : this.dependencies.keySet()) {
+            for (CallContext context : callGraph.getMethodEntryPoint(branch.getClassName(), branch.getMethod())) {
+                CBranchTestFitness cBranch = new CBranchTestFitness(branch.getBranchGoal(), context);
+                this.dependencies.get(branch).add((FitnessFunction<T>) cBranch);
+                logger.debug("Added context branch: " + cBranch.toString());
+            }
+        }
+    }
+
+    /**
+     * This methods derive the dependencies between {@link WeakMutationTestFitness} and branches.
+     * Therefore, it is used to update 'this.dependencies'
+     */
+    private void addDependencies4WeakMutation() {
+        logger.debug("Added dependencies for Weak-Mutation");
+        for (FitnessFunction<T> ff : this.uncoveredGoals){
+            if (ff instanceof WeakMutationTestFitness){
+                WeakMutationTestFitness mutation = (WeakMutationTestFitness) ff;
+                Set<BranchCoverageGoal> goals = mutation.getMutation().getControlDependencies();
+                if (goals.size() == 0){
+                    this.currentGoals.add(ff);
+                } else {
+                    for (BranchCoverageGoal goal : goals) {
+                        BranchCoverageTestFitness fitness = new BranchCoverageTestFitness(goal);
+                        this.dependencies.get(fitness).add(ff);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * This methods derive the dependencies between {@link org.evosuite.coverage.mutation.StrongMutationTestFitness} and branches.
+     * Therefore, it is used to update 'this.dependencies'
+     */
+    private void addDependencies4StrongMutation() {
+        logger.debug("Added dependencies for Strong-Mutation");
+        for (FitnessFunction<T> ff : this.uncoveredGoals){
+            if (ff instanceof StrongMutationTestFitness){
+                StrongMutationTestFitness mutation = (StrongMutationTestFitness) ff;
+                Set<BranchCoverageGoal> goals = mutation.getMutation().getControlDependencies();
+                if (goals.size() == 0){
+                    this.currentGoals.add(ff);
+                } else {
+                    for (BranchCoverageGoal goal : goals) {
+                        BranchCoverageTestFitness fitness = new BranchCoverageTestFitness(goal);
+                        this.dependencies.get(fitness).add(ff);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * This methods derive the dependencies between  {@link LineCoverageTestFitness} and branches.
+     * Therefore, it is used to update 'this.dependencies'
+     */
+    private void addDependencies4Line() {
+        logger.debug("Added dependencies for Lines");
+        for (FitnessFunction<T> ff : this.uncoveredGoals){
+            if (ff instanceof LineCoverageTestFitness){
+                LineCoverageTestFitness line = (LineCoverageTestFitness) ff;
+                ClassLoader loader = TestGenerationContext.getInstance().getClassLoaderForSUT();
+                BytecodeInstructionPool pool = BytecodeInstructionPool.getInstance(loader);
+                BytecodeInstruction instruction = pool.getFirstInstructionAtLineNumber(line.getClassName(), line.getMethod(), line.getLine());
+                Set<ControlDependency> cds = instruction.getControlDependencies();
+                if(cds.size() == 0)
+                    this.currentGoals.add(ff);
+                else {
+                    for (ControlDependency cd : cds) {
+                        BranchCoverageTestFitness fitness = BranchCoverageFactory.createBranchCoverageTestFitness(cd);
+                        this.dependencies.get(fitness).add(ff);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * This methods derive the dependencies between  {@link StatementCoverageTestFitness} and branches.
+     * Therefore, it is used to update 'this.dependencies'
+     */
+    @SuppressWarnings("unchecked")
+    private void addDependencies4Statement() {
+        logger.debug("Added dependencies for Statements");
+        for (FitnessFunction<T> ff : this.uncoveredGoals){
+            if (ff instanceof StatementCoverageTestFitness){
+                StatementCoverageTestFitness stmt = (StatementCoverageTestFitness) ff;
+                if (stmt.getBranchFitnesses().size() == 0)
+                    this.currentGoals.add(ff);
+                else {
+                    for (BranchCoverageTestFitness branch : stmt.getBranchFitnesses()) {
+                        this.dependencies.get(branch).add((FitnessFunction<T>) stmt);
+                    }
+                }
+            }
+        }
+    }
+
+
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void calculateFitness(T c) {
+        // run the test
+        TestCase test = ((TestChromosome) c).getTestCase();
+        ExecutionResult result = TestCaseExecutor.runTest(test);
+        ((TestChromosome) c).setLastExecutionResult(result);
+        c.setChanged(false);
+
+        if (result.hasTimeout() || result.hasTestException()){
+            for (FitnessFunction<T> f : currentGoals)
+                c.setFitness(f, Double.MAX_VALUE);
+            return;
+        }
+
+        Set<MethodCoverageTestFitness> visitedMethods = new HashSet<>();
+
+        // 1) we update the set of currents goals
+        Set<FitnessFunction<T>> visitedTargets = new LinkedHashSet<FitnessFunction<T>>(uncoveredGoals.size()*2);
+        LinkedList<FitnessFunction<T>> targets = new LinkedList<FitnessFunction<T>>();
+        targets.addAll(this.currentGoals);
+
+        while (targets.size()>0){
+            FitnessFunction<T> fitnessFunction = targets.poll();
+
+            int past_size = visitedTargets.size();
+            visitedTargets.add(fitnessFunction);
+            if (past_size == visitedTargets.size())
+                continue;
+
+            double value = fitnessFunction.getFitness(c);
+            if (value == 0.0) {
+                if (fitnessFunction instanceof MethodCoverageTestFitness) {
+                    visitedMethods.add((MethodCoverageTestFitness) fitnessFunction);
+                }
+
+                updateCoveredGoals(fitnessFunction, c);
+                if (fitnessFunction instanceof BranchCoverageTestFitness){
+                    for (FitnessFunction<T> child : graph.getStructuralChildren(fitnessFunction)){
+                        targets.addLast(child);
+                    }
+                    for (FitnessFunction<T> dependentTarget : dependencies.get(fitnessFunction)){
+                        targets.addLast(dependentTarget);
+                    }
+                }
+            } else {
+                currentGoals.add(fitnessFunction);
+            }
+        }
+        //currentGoals.removeAll(coveredGoals.keySet());	//not removing covered goals from currentGoals
+        // 2) we update the archive
+        for (Integer branchid : result.getTrace().getCoveredFalseBranches()){
+            FitnessFunction<T> branch = this.branchCoverageFalseMap.get(branchid);
+            if (branch == null)
+                continue;
+            updateCoveredGoals((FitnessFunction<T>) branch, c);
+        }
+        for (Integer branchid : result.getTrace().getCoveredTrueBranches()){
+            FitnessFunction<T> branch = this.branchCoverageTrueMap.get(branchid);
+            if (branch == null)
+                continue;
+            updateCoveredGoals((FitnessFunction<T>) branch, c);
+        }
+        for (String method : result.getTrace().getCoveredBranchlessMethods()){
+            FitnessFunction<T> branch = this.branchlessMethodCoverageMap.get(method);
+            if (branch == null)
+                continue;
+            updateCoveredGoals((FitnessFunction<T>) branch, c);
+        }
+
+        // let's manage the exception coverage
+        if (ArrayUtil.contains(Properties.CRITERION, EXCEPTION)){
+            // if one of the coverage criterion is Criterion.EXCEPTION,
+            // then we have to analyze the results of the execution do look
+            // for generated exceptions
+            Set<ExceptionCoverageTestFitness> set = deriveCoveredExceptions(c);
+            for (ExceptionCoverageTestFitness exp : set){
+                // let's update the list of fitness functions
+                updateCoveredGoals((FitnessFunction<T>) exp, c);
+                // new covered exceptions (goals) have to be added to the archive
+                if (!ExceptionCoverageFactory.getGoals().containsKey(exp.getKey())){
+                    // let's update the newly discovered exceptions to ExceptionCoverageFactory
+                    ExceptionCoverageFactory.getGoals().put(exp.getKey(), exp);
+                }
+            }
+        }
+
+        if (ArrayUtil.contains(Properties.CRITERION, METHOD)){
+            for (MethodCoverageTestFitness methodFf : this.methods) {
+                if (!visitedMethods.contains(methodFf)) {
+                    double value = ((FitnessFunction) methodFf).getFitness(c);
+                    if (value == 0.0) {
+                        updateCoveredGoals((FitnessFunction) methodFf, c);
+                    }
+                }
+            }
+        }
+
+    }
+
+    /**
+     * This method analyzes the execution results of a TestChromosome looking for generated exceptions.
+     * Such exceptions are converted in instances of the class {@link ExceptionCoverageTestFitness},
+     * which are additional covered goals when using as criterion {@link EXCEPTION}
+     * @param t TestChromosome to analyze
+     * @return list of exception goals being covered by t
+     */
+    public Set<ExceptionCoverageTestFitness> deriveCoveredExceptions(T t){
+        Set<ExceptionCoverageTestFitness> covered_exceptions = new LinkedHashSet<ExceptionCoverageTestFitness>();
+        TestChromosome testCh = (TestChromosome) t;
+        ExecutionResult result = testCh.getLastExecutionResult();
+
+        if(result.calledReflection())
+            return covered_exceptions;
+
+        for (Integer i : result.getPositionsWhereExceptionsWereThrown()) {
+            if(ExceptionCoverageHelper.shouldSkip(result,i)){
+                continue;
+            }
+
+            Class<?> exceptionClass = ExceptionCoverageHelper.getExceptionClass(result,i);
+            String methodIdentifier = ExceptionCoverageHelper.getMethodIdentifier(result, i); //eg name+descriptor
+            boolean sutException = ExceptionCoverageHelper.isSutException(result,i); // was the exception originated by a direct call on the SUT?
+
+            /*
+             * We only consider exceptions that were thrown by calling directly the SUT (not the other
+             * used libraries). However, this would ignore cases in which the SUT is indirectly tested
+             * through another class
+             */
+
+            if (sutException) {
+
+                ExceptionCoverageTestFitness.ExceptionType type = ExceptionCoverageHelper.getType(result,i);
+                /*
+                 * Add goal to list of fitness functions to solve
+                 */
+                ExceptionCoverageTestFitness goal = new ExceptionCoverageTestFitness(Properties.TARGET_CLASS, methodIdentifier, exceptionClass, type);
+                covered_exceptions.add(goal);
+            }
+        }
+        return covered_exceptions;
+    }
+
+    public BranchFitnessGraph getControlDepencies4Branches(){
+        Set<FitnessFunction<T>> setOfBranches = new LinkedHashSet<FitnessFunction<T>>();
+        this.dependencies = new LinkedHashMap();
+
+        List<BranchCoverageTestFitness> branches = new BranchCoverageFactory().getCoverageGoals();
+        for (BranchCoverageTestFitness branch : branches){
+            setOfBranches.add((FitnessFunction<T>) branch);
+            this.dependencies.put(branch, new LinkedHashSet<FitnessFunction<T>>());
+        }
+
+        // initialize the maps
+        this.initializeMaps(setOfBranches);
+
+        return new BranchFitnessGraph<T, FitnessFunction<T>>(setOfBranches);
+    }
+
+    public Map<Integer, FitnessFunction<T>> getBranchCoverageTrueMap() {
+        return branchCoverageTrueMap;
+    }
+
+    public Map<Integer, FitnessFunction<T>> getBranchCoverageFalseMap() {
+        return branchCoverageFalseMap;
+    }
+
+    public int getNumPathsFor(FitnessFunction<T> ff) {
+        return this.numPaths.get(ff);
+    }
+
+    public void updateCurrentGoals() {
+        for (FitnessFunction<T> ff : graph.getRootBranches()) {
+            if (!((BranchCoverageTestFitness) ff).isBuggy()) {
+                this.currentGoals.add(ff);
+            }
+        }
+    }
+
+    public void updateUncoveredGoals() {
+        this.uncoveredGoals.addAll(this.nonBuggyGoals);
+    }
+
+    public void updateMethods() {
+        this.methods.addAll(this.nonBuggyMethods);
+    }
+
+    public void updateBranchCoverageMaps() {
+        branchCoverageTrueMap.putAll(nBBranchCoverageTrueMap);
+        branchCoverageFalseMap.putAll(nBBranchCoverageFalseMap);
+        branchlessMethodCoverageMap.putAll(nBBranchlessMethodCoverageMap);
+    }
+}

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/PredictiveCriteriaManager.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/PredictiveCriteriaManager.java
@@ -151,7 +151,7 @@ public class PredictiveCriteriaManager<T extends Chromosome> extends MultiCriter
                     addDependencies4CBranch();
                     break;
                 default:
-                    LoggingUtils.getEvoLogger().error("The criterion {} is not currently supported in DynaMOSA", criterion.name());
+                    LoggingUtils.getEvoLogger().error("The criterion {} is not currently supported in PreMOSA", criterion.name());
             }
         }
 

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/PredictiveCriteriaManager.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/PredictiveCriteriaManager.java
@@ -64,29 +64,24 @@ public class PredictiveCriteriaManager<T extends Chromosome> extends MultiCriter
 
     private static final Logger logger = LoggerFactory.getLogger(PredictiveCriteriaManager.class);
 
-    protected BranchFitnessGraph<T, FitnessFunction<T>> graph;
-
-    protected Map<BranchCoverageTestFitness, Set<FitnessFunction<T>>> dependencies;
-
+    /** Current methods in the search */
     private Set<MethodCoverageTestFitness> methods;
-    private Set<MethodCoverageTestFitness> nonBuggyMethods = new HashSet<>();;
 
-    private Map<FitnessFunction<T>, Integer> numPaths = new LinkedHashMap<>();
-    private Map<FitnessFunction<T>, Set<FitnessFunction<T>>> children = new LinkedHashMap<>();
+    private Set<MethodCoverageTestFitness> nonBuggyMethods = new HashSet<>();;
 
     private Set<FitnessFunction<T>> nonBuggyGoals;
 
-    protected final Map<Integer, FitnessFunction<T>> branchCoverageTrueMap = new LinkedHashMap<Integer, FitnessFunction<T>>();
-    protected final Map<Integer, FitnessFunction<T>> branchCoverageFalseMap = new LinkedHashMap<Integer, FitnessFunction<T>>();
-    private final Map<String, FitnessFunction<T>> branchlessMethodCoverageMap = new LinkedHashMap<String, FitnessFunction<T>>();
-
+    /** Branch(less) coverage maps of non-buggy goals */
     private final Map<Integer, FitnessFunction<T>> nBBranchCoverageTrueMap = new LinkedHashMap<Integer, FitnessFunction<T>>();
     private final Map<Integer, FitnessFunction<T>> nBBranchCoverageFalseMap = new LinkedHashMap<Integer, FitnessFunction<T>>();
     private final Map<String, FitnessFunction<T>> nBBranchlessMethodCoverageMap = new LinkedHashMap<String, FitnessFunction<T>>();
 
     public PredictiveCriteriaManager(List<FitnessFunction<T>> fitnessFunctions) {
         super(fitnessFunctions);
+    }
 
+    @Override
+    protected void init(List<FitnessFunction<T>> fitnessFunctions) {
         nonBuggyGoals = new HashSet<FitnessFunction<T>>(fitnessFunctions.size());
 
         // initialize uncovered goals and find nonBuggyGoals

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/PredictiveCriteriaManager.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/PredictiveCriteriaManager.java
@@ -174,8 +174,10 @@ public class PredictiveCriteriaManager<T extends Chromosome> extends MultiCriter
             }
         }
 
-        // Calculate number of independent paths leading up from each target (goal)
-        calculateIndependentPaths(fitnessFunctions);
+        if (Properties.BALANCE_TEST_COV) {
+            // Calculate number of independent paths leading up from each target (goal)
+            calculateIndependentPaths(fitnessFunctions);
+        }
     }
 
     private void initMethods(List<FitnessFunction<T>> fitnessFunctions) {

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/PredictiveCriteriaManager.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/PredictiveCriteriaManager.java
@@ -327,14 +327,6 @@ public class PredictiveCriteriaManager<T extends Chromosome> extends MultiCriter
 
     }
 
-    public Map<Integer, FitnessFunction<T>> getBranchCoverageTrueMap() {
-        return branchCoverageTrueMap;
-    }
-
-    public Map<Integer, FitnessFunction<T>> getBranchCoverageFalseMap() {
-        return branchCoverageFalseMap;
-    }
-
     public void updateCurrentGoals() {
         for (FitnessFunction<T> ff : graph.getRootBranches()) {
             if (!((BranchCoverageTestFitness) ff).isBuggy()) {

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/PredictiveCriteriaManager.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/PredictiveCriteriaManager.java
@@ -65,7 +65,7 @@ public class PredictiveCriteriaManager<T extends Chromosome> extends MultiCriter
     private static final Logger logger = LoggerFactory.getLogger(PredictiveCriteriaManager.class);
 
     /** Current methods in the search */
-    private Set<MethodCoverageTestFitness> methods;
+    private Set<MethodCoverageTestFitness> methods = new HashSet<>();
 
     private Set<MethodCoverageTestFitness> nonBuggyMethods = new HashSet<>();;
 
@@ -85,7 +85,6 @@ public class PredictiveCriteriaManager<T extends Chromosome> extends MultiCriter
         nonBuggyGoals = new HashSet<FitnessFunction<T>>(fitnessFunctions.size());
 
         // initialize uncovered goals and find nonBuggyGoals
-        // uncoveredGoals.addAll(fitnessFunctions);
         for (FitnessFunction<T> ff : fitnessFunctions) {
             if (ff instanceof BranchCoverageTestFitness) {
                 if (((BranchCoverageTestFitness) ff).isBuggy()) {
@@ -110,7 +109,8 @@ public class PredictiveCriteriaManager<T extends Chromosome> extends MultiCriter
         // initialize the dependency graph among branches
         this.graph = getControlDepencies4Branches();
 
-        this.methods = getMethods(fitnessFunctions, this.nonBuggyMethods);
+        // initialize methods and non-buggy methods
+        initMethods(fitnessFunctions);
 
         // initialize the dependency graph between branches and other coverage targets (e.g., statements)
         // let's derive the dependency graph between branches and other coverage targets (e.g., statements)
@@ -156,88 +156,30 @@ public class PredictiveCriteriaManager<T extends Chromosome> extends MultiCriter
         }
 
         // initialize current goals
-        // this.currentGoals.addAll(graph.getRootBranches());
         for (FitnessFunction<T> ff : graph.getRootBranches()) {
             if (((BranchCoverageTestFitness) ff).isBuggy()) {
                 this.currentGoals.add(ff);
             }
         }
 
-        long pathsCalculationStartTime = System.nanoTime();
-        for (FitnessFunction<T> rootBranch : graph.getRootBranches()) {
-            Set<FitnessFunction<T>> allParents = new HashSet<>();
-            graph.getAllStructuralChildren(rootBranch, this.children, allParents);
-        }
-
-        for (FitnessFunction<T> ff : fitnessFunctions) {
-            if (ff instanceof BranchCoverageTestFitness) {
-                if (!this.children.containsKey(ff)) {
-                    logger.error("Children not found for {}", ff.toString());
-                    Set<FitnessFunction<T>> allParents = new HashSet<>();
-                    graph.getAllStructuralChildren(ff, this.children, allParents);
-                }
-
-                this.numPaths.put(ff, calculateNumPaths(this.children.get(ff)));
-            }
-        }
-        long pathsCalculationEndTime = System.nanoTime();
-        LoggingUtils.getEvoLogger().info("Paths Calculation Overhead: {} ms",
-                (double) (pathsCalculationEndTime - pathsCalculationStartTime) / 1000000);
+        // Calculate number of independent paths leading up from each target (goal)
+        calculateIndependentPaths(fitnessFunctions);
     }
 
-    private Set<MethodCoverageTestFitness> getMethods(List<FitnessFunction<T>> fitnessFunctions,
-                                                      Set<MethodCoverageTestFitness> nonBuggyMethods) {
-        Set<MethodCoverageTestFitness> methods = new HashSet<>();
+    private void initMethods(List<FitnessFunction<T>> fitnessFunctions) {
         for (FitnessFunction<T> ff : fitnessFunctions) {
             if (ff instanceof MethodCoverageTestFitness) {
                 if (((MethodCoverageTestFitness) ff).isBuggy()) {
-                    methods.add((MethodCoverageTestFitness) ff);
+                    this.methods.add((MethodCoverageTestFitness) ff);
                 } else {
-                    nonBuggyMethods.add((MethodCoverageTestFitness) ff);
+                    this.nonBuggyMethods.add((MethodCoverageTestFitness) ff);
                 }
             }
         }
-
-        return methods;
     }
 
-    private Integer calculateNumPaths(Set<FitnessFunction<T>> childrenOf) {
-        Map<Branch, Integer> numChildren = new HashMap<>();
-        Set<Branch> cdNodes = new HashSet<>();
-
-        for (FitnessFunction<T> ff : childrenOf) {
-            Branch branch = ((BranchCoverageTestFitness) ff).getBranch();
-            if (numChildren.containsKey(branch)) {
-                int numChildrenForB = numChildren.get(branch);
-                numChildrenForB++;
-                numChildren.put(branch, numChildrenForB);
-
-                if (numChildrenForB == 2) {
-                    cdNodes.add(branch);
-                } else if (numChildrenForB > 2) {
-                    logger.error("Unexpected number of children for {}", branch.toString());
-                }
-            } else {
-                numChildren.put(branch, 1);
-            }
-        }
-
-        return cdNodes.size() + 1;
-    }
-
-    @SuppressWarnings("unchecked")
-    private void addDependencies4TryCatch() {
-        logger.debug("Added dependencies for Try-Catch");
-        for (FitnessFunction<T> ff : this.uncoveredGoals){
-            if (ff instanceof TryCatchCoverageTestFitness){
-                TryCatchCoverageTestFitness stmt = (TryCatchCoverageTestFitness) ff;
-                BranchCoverageTestFitness branch = new BranchCoverageTestFitness(stmt.getBranchGoal());
-                this.dependencies.get(branch).add((FitnessFunction<T>) stmt);
-            }
-        }
-    }
-
-    private void initializeMaps(Set<FitnessFunction<T>> set){
+    @Override
+    protected void initializeMaps(Set<FitnessFunction<T>> set){
         for (FitnessFunction<T> ff : set) {
             BranchCoverageTestFitness goal = (BranchCoverageTestFitness) ff;
             // Skip instrumented branches - we only want real branches
@@ -272,201 +214,6 @@ public class PredictiveCriteriaManager<T extends Chromosome> extends MultiCriter
             }
         }
     }
-
-    private void addDependencies4Output() {
-        logger.debug("Added dependencies for Output");
-        for (FitnessFunction<T> ff : this.uncoveredGoals){
-            if (ff instanceof OutputCoverageTestFitness){
-                OutputCoverageTestFitness output = (OutputCoverageTestFitness) ff;
-                ClassLoader loader = TestGenerationContext.getInstance().getClassLoaderForSUT();
-                BytecodeInstructionPool pool = BytecodeInstructionPool.getInstance(loader);
-                if (pool.getInstructionsIn(output.getClassName(), output.getMethod()) == null){
-                    this.currentGoals.add(ff);
-                    continue;
-                }
-                for (BytecodeInstruction instruction : pool.getInstructionsIn(output.getClassName(), output.getMethod())) {
-                    if (instruction.getBasicBlock() != null){
-                        Set<ControlDependency> cds = instruction.getBasicBlock().getControlDependencies();
-                        if (cds.size()==0){
-                            this.currentGoals.add(ff);
-                        } else {
-                            for (ControlDependency cd : cds) {
-                                BranchCoverageTestFitness fitness = BranchCoverageFactory.createBranchCoverageTestFitness(cd);
-                                this.dependencies.get(fitness).add(ff);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * This methods derive the dependencies between {@link InputCoverageTestFitness} and branches.
-     * Therefore, it is used to update 'this.dependencies'
-     */
-    private void addDependencies4Input() {
-        logger.debug("Added dependencies for Input");
-        for (FitnessFunction<T> ff : this.uncoveredGoals){
-            if (ff instanceof InputCoverageTestFitness){
-                InputCoverageTestFitness input = (InputCoverageTestFitness) ff;
-                ClassLoader loader = TestGenerationContext.getInstance().getClassLoaderForSUT();
-                BytecodeInstructionPool pool = BytecodeInstructionPool.getInstance(loader);
-                if (pool.getInstructionsIn(input.getClassName(), input.getMethod()) == null) {
-                    this.currentGoals.add(ff);
-                    continue;
-                }
-                for (BytecodeInstruction instruction : pool.getInstructionsIn(input.getClassName(), input.getMethod())) {
-                    if (instruction.getBasicBlock() != null){
-                        Set<ControlDependency> cds = instruction.getBasicBlock().getControlDependencies();
-                        if (cds.size()==0){
-                            this.currentGoals.add(ff);
-                        } else {
-                            for (ControlDependency cd : cds) {
-                                BranchCoverageTestFitness fitness = BranchCoverageFactory.createBranchCoverageTestFitness(cd);
-                                this.dependencies.get(fitness).add(ff);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * This methods derive the dependencies between {@link MethodCoverageTestFitness} and branches.
-     * Therefore, it is used to update 'this.dependencies'
-     */
-    @SuppressWarnings("unchecked")
-    private void addDependencies4Methods() {
-        logger.debug("Added dependencies for Methods");
-        for (BranchCoverageTestFitness branch : this.dependencies.keySet()){
-            MethodCoverageTestFitness method = new MethodCoverageTestFitness(branch.getClassName(), branch.getMethod());
-            this.dependencies.get(branch).add((FitnessFunction<T>) method);
-        }
-    }
-
-    /**
-     * This methods derive the dependencies between {@link MethodNoExceptionCoverageTestFitness} and branches.
-     * Therefore, it is used to update 'this.dependencies'
-     */
-    @SuppressWarnings("unchecked")
-    private void addDependencies4MethodsNoException() {
-        logger.debug("Added dependencies for MethodsNoException");
-        for (BranchCoverageTestFitness branch : this.dependencies.keySet()){
-            MethodNoExceptionCoverageTestFitness method = new MethodNoExceptionCoverageTestFitness(branch.getClassName(), branch.getMethod());
-            this.dependencies.get(branch).add((FitnessFunction<T>) method);
-        }
-    }
-
-    /**
-     * This methods derive the dependencies between {@link CBranchTestFitness} and branches.
-     * Therefore, it is used to update 'this.dependencies'
-     */
-    @SuppressWarnings("unchecked")
-    private void addDependencies4CBranch() {
-        logger.debug("Added dependencies for CBranch");
-        CallGraph callGraph = DependencyAnalysis.getCallGraph();
-        for (BranchCoverageTestFitness branch : this.dependencies.keySet()) {
-            for (CallContext context : callGraph.getMethodEntryPoint(branch.getClassName(), branch.getMethod())) {
-                CBranchTestFitness cBranch = new CBranchTestFitness(branch.getBranchGoal(), context);
-                this.dependencies.get(branch).add((FitnessFunction<T>) cBranch);
-                logger.debug("Added context branch: " + cBranch.toString());
-            }
-        }
-    }
-
-    /**
-     * This methods derive the dependencies between {@link WeakMutationTestFitness} and branches.
-     * Therefore, it is used to update 'this.dependencies'
-     */
-    private void addDependencies4WeakMutation() {
-        logger.debug("Added dependencies for Weak-Mutation");
-        for (FitnessFunction<T> ff : this.uncoveredGoals){
-            if (ff instanceof WeakMutationTestFitness){
-                WeakMutationTestFitness mutation = (WeakMutationTestFitness) ff;
-                Set<BranchCoverageGoal> goals = mutation.getMutation().getControlDependencies();
-                if (goals.size() == 0){
-                    this.currentGoals.add(ff);
-                } else {
-                    for (BranchCoverageGoal goal : goals) {
-                        BranchCoverageTestFitness fitness = new BranchCoverageTestFitness(goal);
-                        this.dependencies.get(fitness).add(ff);
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * This methods derive the dependencies between {@link org.evosuite.coverage.mutation.StrongMutationTestFitness} and branches.
-     * Therefore, it is used to update 'this.dependencies'
-     */
-    private void addDependencies4StrongMutation() {
-        logger.debug("Added dependencies for Strong-Mutation");
-        for (FitnessFunction<T> ff : this.uncoveredGoals){
-            if (ff instanceof StrongMutationTestFitness){
-                StrongMutationTestFitness mutation = (StrongMutationTestFitness) ff;
-                Set<BranchCoverageGoal> goals = mutation.getMutation().getControlDependencies();
-                if (goals.size() == 0){
-                    this.currentGoals.add(ff);
-                } else {
-                    for (BranchCoverageGoal goal : goals) {
-                        BranchCoverageTestFitness fitness = new BranchCoverageTestFitness(goal);
-                        this.dependencies.get(fitness).add(ff);
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * This methods derive the dependencies between  {@link LineCoverageTestFitness} and branches.
-     * Therefore, it is used to update 'this.dependencies'
-     */
-    private void addDependencies4Line() {
-        logger.debug("Added dependencies for Lines");
-        for (FitnessFunction<T> ff : this.uncoveredGoals){
-            if (ff instanceof LineCoverageTestFitness){
-                LineCoverageTestFitness line = (LineCoverageTestFitness) ff;
-                ClassLoader loader = TestGenerationContext.getInstance().getClassLoaderForSUT();
-                BytecodeInstructionPool pool = BytecodeInstructionPool.getInstance(loader);
-                BytecodeInstruction instruction = pool.getFirstInstructionAtLineNumber(line.getClassName(), line.getMethod(), line.getLine());
-                Set<ControlDependency> cds = instruction.getControlDependencies();
-                if(cds.size() == 0)
-                    this.currentGoals.add(ff);
-                else {
-                    for (ControlDependency cd : cds) {
-                        BranchCoverageTestFitness fitness = BranchCoverageFactory.createBranchCoverageTestFitness(cd);
-                        this.dependencies.get(fitness).add(ff);
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * This methods derive the dependencies between  {@link StatementCoverageTestFitness} and branches.
-     * Therefore, it is used to update 'this.dependencies'
-     */
-    @SuppressWarnings("unchecked")
-    private void addDependencies4Statement() {
-        logger.debug("Added dependencies for Statements");
-        for (FitnessFunction<T> ff : this.uncoveredGoals){
-            if (ff instanceof StatementCoverageTestFitness){
-                StatementCoverageTestFitness stmt = (StatementCoverageTestFitness) ff;
-                if (stmt.getBranchFitnesses().size() == 0)
-                    this.currentGoals.add(ff);
-                else {
-                    for (BranchCoverageTestFitness branch : stmt.getBranchFitnesses()) {
-                        this.dependencies.get(branch).add((FitnessFunction<T>) stmt);
-                    }
-                }
-            }
-        }
-    }
-
-
 
     @SuppressWarnings("unchecked")
     @Override
@@ -568,75 +315,12 @@ public class PredictiveCriteriaManager<T extends Chromosome> extends MultiCriter
 
     }
 
-    /**
-     * This method analyzes the execution results of a TestChromosome looking for generated exceptions.
-     * Such exceptions are converted in instances of the class {@link ExceptionCoverageTestFitness},
-     * which are additional covered goals when using as criterion {@link EXCEPTION}
-     * @param t TestChromosome to analyze
-     * @return list of exception goals being covered by t
-     */
-    public Set<ExceptionCoverageTestFitness> deriveCoveredExceptions(T t){
-        Set<ExceptionCoverageTestFitness> covered_exceptions = new LinkedHashSet<ExceptionCoverageTestFitness>();
-        TestChromosome testCh = (TestChromosome) t;
-        ExecutionResult result = testCh.getLastExecutionResult();
-
-        if(result.calledReflection())
-            return covered_exceptions;
-
-        for (Integer i : result.getPositionsWhereExceptionsWereThrown()) {
-            if(ExceptionCoverageHelper.shouldSkip(result,i)){
-                continue;
-            }
-
-            Class<?> exceptionClass = ExceptionCoverageHelper.getExceptionClass(result,i);
-            String methodIdentifier = ExceptionCoverageHelper.getMethodIdentifier(result, i); //eg name+descriptor
-            boolean sutException = ExceptionCoverageHelper.isSutException(result,i); // was the exception originated by a direct call on the SUT?
-
-            /*
-             * We only consider exceptions that were thrown by calling directly the SUT (not the other
-             * used libraries). However, this would ignore cases in which the SUT is indirectly tested
-             * through another class
-             */
-
-            if (sutException) {
-
-                ExceptionCoverageTestFitness.ExceptionType type = ExceptionCoverageHelper.getType(result,i);
-                /*
-                 * Add goal to list of fitness functions to solve
-                 */
-                ExceptionCoverageTestFitness goal = new ExceptionCoverageTestFitness(Properties.TARGET_CLASS, methodIdentifier, exceptionClass, type);
-                covered_exceptions.add(goal);
-            }
-        }
-        return covered_exceptions;
-    }
-
-    public BranchFitnessGraph getControlDepencies4Branches(){
-        Set<FitnessFunction<T>> setOfBranches = new LinkedHashSet<FitnessFunction<T>>();
-        this.dependencies = new LinkedHashMap();
-
-        List<BranchCoverageTestFitness> branches = new BranchCoverageFactory().getCoverageGoals();
-        for (BranchCoverageTestFitness branch : branches){
-            setOfBranches.add((FitnessFunction<T>) branch);
-            this.dependencies.put(branch, new LinkedHashSet<FitnessFunction<T>>());
-        }
-
-        // initialize the maps
-        this.initializeMaps(setOfBranches);
-
-        return new BranchFitnessGraph<T, FitnessFunction<T>>(setOfBranches);
-    }
-
     public Map<Integer, FitnessFunction<T>> getBranchCoverageTrueMap() {
         return branchCoverageTrueMap;
     }
 
     public Map<Integer, FitnessFunction<T>> getBranchCoverageFalseMap() {
         return branchCoverageFalseMap;
-    }
-
-    public int getNumPathsFor(FitnessFunction<T> ff) {
-        return this.numPaths.get(ff);
     }
 
     public void updateCurrentGoals() {

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/PredictiveCriteriaManager.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/PredictiveCriteriaManager.java
@@ -65,19 +65,31 @@ public class PredictiveCriteriaManager<T extends Chromosome> extends MultiCriter
     private static final Logger logger = LoggerFactory.getLogger(PredictiveCriteriaManager.class);
 
     /** Current methods in the search */
-    private Set<MethodCoverageTestFitness> methods = new HashSet<>();
+    private Set<MethodCoverageTestFitness> methods;
 
-    private Set<MethodCoverageTestFitness> nonBuggyMethods = new HashSet<>();;
+    private Set<MethodCoverageTestFitness> nonBuggyMethods;
 
     private Set<FitnessFunction<T>> nonBuggyGoals;
 
     /** Branch(less) coverage maps of non-buggy goals */
-    private final Map<Integer, FitnessFunction<T>> nBBranchCoverageTrueMap = new LinkedHashMap<Integer, FitnessFunction<T>>();
-    private final Map<Integer, FitnessFunction<T>> nBBranchCoverageFalseMap = new LinkedHashMap<Integer, FitnessFunction<T>>();
-    private final Map<String, FitnessFunction<T>> nBBranchlessMethodCoverageMap = new LinkedHashMap<String, FitnessFunction<T>>();
+    private Map<Integer, FitnessFunction<T>> nBBranchCoverageTrueMap;
+    private Map<Integer, FitnessFunction<T>> nBBranchCoverageFalseMap;
+    private Map<String, FitnessFunction<T>> nBBranchlessMethodCoverageMap;
 
     public PredictiveCriteriaManager(List<FitnessFunction<T>> fitnessFunctions) {
         super(fitnessFunctions);
+    }
+
+    @Override
+    protected void instantiateAttributes() {
+        super.instantiateAttributes();
+
+        methods = new HashSet<>();
+        nonBuggyMethods = new HashSet<>();
+
+        nBBranchCoverageTrueMap = new LinkedHashMap<Integer, FitnessFunction<T>>();
+        nBBranchCoverageFalseMap = new LinkedHashMap<Integer, FitnessFunction<T>>();
+        nBBranchlessMethodCoverageMap = new LinkedHashMap<String, FitnessFunction<T>>();
     }
 
     @Override

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/StructuralGoalManager.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/StructuralGoalManager.java
@@ -65,7 +65,9 @@ public abstract class StructuralGoalManager<T extends Chromosome> {
 		init(fitnessFunctions);
 	}
 
-	protected abstract void init(List<FitnessFunction<T>> fitnessFunctions);
+	protected void init(List<FitnessFunction<T>> fitnessFunctions) {
+
+	}
 
 	/**
 	 * Update the set of covered goals and the set of current goals (actual objectives)

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/StructuralGoalManager.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/StructuralGoalManager.java
@@ -61,7 +61,11 @@ public abstract class StructuralGoalManager<T extends Chromosome> {
 		coveredGoals = new HashMap<FitnessFunction<T>, T>(fitnessFunctions.size());
 		archive = new HashMap<T, List<FitnessFunction<T>>>();
 		tests = new HashMap<>(fitnessFunctions.size());
+
+		init(fitnessFunctions);
 	}
+
+	protected abstract void init(List<FitnessFunction<T>> fitnessFunctions);
 
 	/**
 	 * Update the set of covered goals and the set of current goals (actual objectives)

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/StructuralGoalManager.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/StructuralGoalManager.java
@@ -82,17 +82,6 @@ public abstract class StructuralGoalManager<T extends Chromosome> {
 		return coveredGoals;
 	}
 
-	protected boolean isAlreadyCovered(FitnessFunction<T> target){
-		if (uncoveredGoals.size() < coveredGoals.keySet().size()){
-			if (!uncoveredGoals.contains(target))
-				return true;
-		} else {
-			if (coveredGoals.keySet().contains(target))
-				return true;
-		}
-		return false;
-	}
-
 	protected void updateCoveredGoals(FitnessFunction<T> f, T tc) {
 		// the next two lines are needed since that coverage information are used
 		// during EvoSuite post-processing

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/StructuralGoalManager.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/StructuralGoalManager.java
@@ -61,12 +61,6 @@ public abstract class StructuralGoalManager<T extends Chromosome> {
 		coveredGoals = new HashMap<FitnessFunction<T>, T>(fitnessFunctions.size());
 		archive = new HashMap<T, List<FitnessFunction<T>>>();
 		tests = new HashMap<>(fitnessFunctions.size());
-
-		init(fitnessFunctions);
-	}
-
-	protected void init(List<FitnessFunction<T>> fitnessFunctions) {
-
 	}
 
 	/**

--- a/client/src/main/java/org/evosuite/strategy/PropertiesSuiteGAFactory.java
+++ b/client/src/main/java/org/evosuite/strategy/PropertiesSuiteGAFactory.java
@@ -34,6 +34,7 @@ import org.evosuite.ga.archive.ArchiveTestChromosomeFactory;
 import org.evosuite.ga.metaheuristics.*;
 import org.evosuite.ga.metaheuristics.mosa.MOSA;
 import org.evosuite.ga.metaheuristics.mosa.DynaMOSA;
+import org.evosuite.ga.metaheuristics.mosa.PreMOSA;
 import org.evosuite.ga.metaheuristics.mulambda.MuLambdaEA;
 import org.evosuite.ga.metaheuristics.mulambda.MuPlusLambdaEA;
 import org.evosuite.ga.metaheuristics.mulambda.OnePlusLambdaLambdaGA;
@@ -203,6 +204,9 @@ public class PropertiesSuiteGAFactory extends PropertiesSearchAlgorithmFactory<T
         case DYNAMOSA:
         	logger.info("Chosen search algorithm: DynaMOSA");
             return new DynaMOSA<TestSuiteChromosome>(factory);
+		case PREMOSA:
+			logger.info("Chosen search algorithm: PreMOSA");
+			return new PreMOSA<TestSuiteChromosome>(factory);
         case ONE_PLUS_LAMBDA_LAMBDA_GA:
             logger.info("Chosen search algorithm: 1 + (lambda, lambda)GA");
             {


### PR DESCRIPTION
- Create a new class for PreMOSA.
- Use PredictiveCriteriaManager to handle buggy methods predictions, and leave only the balance test coverage tasks to MutliCriteriatManager.
- Both PreMOSA and DynaMOSA can use balance test coverage (if the option is enabled), and predictions only in PreMOSA.