### PR TITLE
Add options to configure update targets and archive functions

### DIFF
--- a/client/src/main/java/org/evosuite/Properties.java
+++ b/client/src/main/java/org/evosuite/Properties.java
@@ -1240,6 +1240,9 @@ public class Properties {
 	@Parameter(key = "archive_type", description = "Which type of archive to keep track of covered goals during search")
 	public static ArchiveType ARCHIVE_TYPE = ArchiveType.COVERAGE;
 
+	@Parameter(key = "archive_all", description = "Archive all the test cases generated")
+	public static boolean ARCHIVE_ALL = false;
+
 	@Parameter(key = "seed_file", description = "File storing TestGenerationResult or GeneticAlgorithm")
 	public static String SEED_FILE = "";
 

--- a/client/src/main/java/org/evosuite/Properties.java
+++ b/client/src/main/java/org/evosuite/Properties.java
@@ -1317,6 +1317,9 @@ public class Properties {
 	@Parameter(key = "balance_test_cov", description = "Enable balanced test coverage of targets")
 	public static boolean BALANCE_TEST_COV = false;
 
+	@Parameter(key = "remove_covered_targets", description = "Remove covered targets from the search")
+	public static boolean REMOVE_COVERED_TARGETS = true;
+
 	// ---------------------------------------------------------------
 	// Contracts / Asserts:
 	@Parameter(key = "check_contracts", description = "Check contracts during test execution")

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/DynaMOSA.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/DynaMOSA.java
@@ -211,7 +211,7 @@ public class DynaMOSA<T extends Chromosome> extends AbstractMOSA<T> {
 		}
 
 		// next generations
-		while (!isFinished() /*&& this.goalsManager.getUncoveredGoals().size() > 0*/) {
+		while (!isFinished() /*&& this.goalsManager.getUncoveredGoals().size() > 0*/) {	// second condition is handled by stop_zero option
 			this.evolve();
 			this.notifyIteration();
 		}

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/MultiCriteriatManager.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/MultiCriteriatManager.java
@@ -469,7 +469,11 @@ public class MultiCriteriatManager<T extends Chromosome> extends StructuralGoalM
 				currentGoals.add(fitnessFunction);
 			}	
 		}
-		//currentGoals.removeAll(coveredGoals.keySet());	//not removing covered goals from currentGoals
+
+		if (Properties.REMOVE_COVERED_TARGETS) {
+			currentGoals.removeAll(coveredGoals.keySet());
+		}
+
 		// 2) we update the archive
 		for (Integer branchid : result.getTrace().getCoveredFalseBranches()){
 			FitnessFunction<T> branch = this.branchCoverageFalseMap.get(branchid);

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/StructuralGoalManager.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/structural/StructuralGoalManager.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.evosuite.Properties;
 import org.evosuite.coverage.branch.BranchCoverageTestFitness;
 import org.evosuite.ga.Chromosome;
 import org.evosuite.ga.FitnessFunction;
@@ -95,19 +96,28 @@ public abstract class StructuralGoalManager<T extends Chromosome> {
 			toArchive = true;
 			coveredGoals.put(f, tc);
 			uncoveredGoals.remove(f);
-			//currentGoals.remove(f);	//not removing covered goals from currentGoals
+			if (Properties.REMOVE_COVERED_TARGETS) {
+				currentGoals.remove(f);    // removing covered goals from currentGoals
+			}
 		} else {
 			double bestSize = best.size();
 			double size = tc.size();
 			if (size < bestSize && size > 1){
 				toArchive = true;
 				coveredGoals.put(f, tc);
-				/*archive.get(best).remove(f);
-				if (archive.get(best).size() == 0)
-					archive.remove(best);*/
+				if (!Properties.ARCHIVE_ALL) {
+					archive.get(best).remove(f);
+					if (archive.get(best).size() == 0) {
+						archive.remove(best);
+						removeFromTests(best);
+					}
+				}
 			}
 		}
-		toArchive = true;	//since we want to archive the test case anyway
+
+		if (Properties.ARCHIVE_ALL) {
+			toArchive = true;    // since we want to archive the test case anyway
+		}
 
 		// update archive
 		if (toArchive){
@@ -120,9 +130,17 @@ public abstract class StructuralGoalManager<T extends Chromosome> {
 				coveredTargets.add(f);
 			}
 
-			if (f instanceof BranchCoverageTestFitness) {
-				addTestTo(f, tc);
+			if (Properties.BALANCE_TEST_COV) {
+				if (f instanceof BranchCoverageTestFitness) {
+					addTestTo(f, tc);
+				}
 			}
+		}
+	}
+
+	private void removeFromTests(T tc) {
+		for (Set<T> testsForFf : tests.values()) {
+			testsForFf.remove(tc);
 		}
 	}
 

--- a/client/src/main/java/org/evosuite/strategy/PropertiesSuiteGAFactory.java
+++ b/client/src/main/java/org/evosuite/strategy/PropertiesSuiteGAFactory.java
@@ -214,6 +214,8 @@ public class PropertiesSuiteGAFactory extends PropertiesSearchAlgorithmFactory<T
 			Properties.REMOVE_COVERED_TARGETS = false;
 			// PreMOSA does not stop after all the goals/targets are covered
 			Properties.STOP_ZERO = false;
+			// PreMOSA archives all the test cases by default
+			Properties.ARCHIVE_ALL = true;
 			return new PreMOSA<TestSuiteChromosome>(factory);
         case ONE_PLUS_LAMBDA_LAMBDA_GA:
             logger.info("Chosen search algorithm: 1 + (lambda, lambda)GA");

--- a/client/src/main/java/org/evosuite/strategy/PropertiesSuiteGAFactory.java
+++ b/client/src/main/java/org/evosuite/strategy/PropertiesSuiteGAFactory.java
@@ -212,6 +212,8 @@ public class PropertiesSuiteGAFactory extends PropertiesSearchAlgorithmFactory<T
 			logger.info("Chosen search algorithm: PreMOSA");
 			// PreMOSA does not remove covered targets from the search by default
 			Properties.REMOVE_COVERED_TARGETS = false;
+			// PreMOSA does not stop after all the goals/targets are covered
+			Properties.STOP_ZERO = false;
 			return new PreMOSA<TestSuiteChromosome>(factory);
         case ONE_PLUS_LAMBDA_LAMBDA_GA:
             logger.info("Chosen search algorithm: 1 + (lambda, lambda)GA");

--- a/client/src/main/java/org/evosuite/strategy/PropertiesSuiteGAFactory.java
+++ b/client/src/main/java/org/evosuite/strategy/PropertiesSuiteGAFactory.java
@@ -203,9 +203,15 @@ public class PropertiesSuiteGAFactory extends PropertiesSearchAlgorithmFactory<T
             return new MOSA<TestSuiteChromosome>(factory);
         case DYNAMOSA:
         	logger.info("Chosen search algorithm: DynaMOSA");
-            return new DynaMOSA<TestSuiteChromosome>(factory);
+            if (Properties.BALANCE_TEST_COV) {
+            	// Balanced test coverage is only used when covered targets are not removed from the search
+            	Properties.REMOVE_COVERED_TARGETS = false;
+			}
+        	return new DynaMOSA<TestSuiteChromosome>(factory);
 		case PREMOSA:
 			logger.info("Chosen search algorithm: PreMOSA");
+			// PreMOSA does not remove covered targets from the search by default
+			Properties.REMOVE_COVERED_TARGETS = false;
 			return new PreMOSA<TestSuiteChromosome>(factory);
         case ONE_PLUS_LAMBDA_LAMBDA_GA:
             logger.info("Chosen search algorithm: 1 + (lambda, lambda)GA");


### PR DESCRIPTION
- ARCHIVE_ALL - If true, archive all the test cases generated, else, archive only the best test case (i.e., shortest)
- REMOVE_COVERED_TARGETS - If true, remove covered targets from the search (as in original DynaMOSA), else, do not remove covered targets from the search (default in PreMOSA).
- Also, force PreMOSA to not to stop the search once it covers all the coverage goals/targets.
